### PR TITLE
ci(release): add multi-platform builds for Linux, Windows and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,12 +195,23 @@ jobs:
             echo 'EOF'
           } >> $GITHUB_OUTPUT
 
-  build:
+  build-linux:
     needs: changelog
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
         run: |
@@ -213,20 +224,117 @@ jobs:
           cmake .. -DCMAKE_BUILD_TYPE=Release
           cmake --build .
 
+      - name: Rename binary
+        run: mv build/torrent_builder torrent_builder_${{ steps.version.outputs.VERSION }}_linux_${{ matrix.arch }}
+
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: torrent-builder-linux-x86_64
-          path: build/torrent_builder
+          name: torrent-builder-linux-${{ matrix.arch }}
+          path: torrent_builder_${{ steps.version.outputs.VERSION }}_linux_${{ matrix.arch }}
+
+  build-windows:
+    needs: changelog
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            arch: amd64
+            msystem: UCRT64
+            prefix: mingw-w64-ucrt-x86_64
+          - os: windows-11-arm
+            arch: arm64
+            msystem: CLANGARM64
+            prefix: mingw-w64-clang-aarch64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Get version from tag
+        id: version
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >-
+            git
+            base-devel
+            ${{ matrix.prefix }}-cmake
+            ${{ matrix.prefix }}-libtorrent-rasterbar
+            ${{ matrix.prefix }}-pkg-config
+
+      - name: Build
+        shell: msys2 {0}
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release -G "MSYS Makefiles"
+          cmake --build .
+
+      - name: Rename binary
+        shell: bash
+        run: mv build/torrent_builder.exe torrent_builder_${{ steps.version.outputs.VERSION }}_windows_${{ matrix.arch }}.exe
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: torrent-builder-windows-${{ matrix.arch }}
+          path: torrent_builder_${{ steps.version.outputs.VERSION }}_windows_${{ matrix.arch }}.exe
+
+  build-macos:
+    needs: changelog
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+          - os: macos-15
+            arch: amd64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Install dependencies
+        run: brew install cmake libtorrent-rasterbar pkg-config
+
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake --build .
+
+      - name: Rename and package
+        run: |
+          mv build/torrent_builder torrent_builder
+          zip torrent_builder_${{ steps.version.outputs.VERSION }}_macos_${{ matrix.arch }}.zip torrent_builder
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: torrent-builder-macos-${{ matrix.arch }}
+          path: torrent_builder_${{ steps.version.outputs.VERSION }}_macos_${{ matrix.arch }}.zip
 
   release:
-    needs: [changelog, build]
+    needs: [changelog, build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
     steps:
-      - name: Download binary
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          name: torrent-builder-linux-x86_64
+          path: bin
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la bin/
 
       - name: Create Release
         uses: softprops/action-gh-release@v3
@@ -234,4 +342,4 @@ jobs:
           body: ${{ needs.changelog.outputs.changelog }}
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') }}
-          files: torrent_builder
+          files: bin/*


### PR DESCRIPTION
## Summary
This PR expands the release CI workflow from a single Linux/amd64 build to comprehensive multi-platform builds supporting Linux (amd64, arm64), Windows (amd64 & arm64 via MSYS2 toolchains), and macOS (amd64, arm64). This enables distribution of native, optimized binaries for all major desktop platforms that libtorrent-rasterbar supports.

## Pipeline Changes
- **Replaced** the single `build` job with three platform-specific jobs: `build-linux`, `build-windows`, and `build-macos`
- **Linux builds**: Matrix strategy using `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64) with apt-installed dependencies
- **Windows builds**: Matrix strategy using MSYS2 environments — `UCRT64` for amd64 and `CLANGARM64` for arm64 — installing mingw-w64 toolchains and libtorrent-rasterbar via `pacman`
- **macOS builds**: Matrix strategy using `macos-latest` (arm64) and `macos-15` (amd64) with Homebrew-installed dependencies (`cmake`, `libtorrent-rasterbar`, `pkg-config`)
- **Binary naming**: Each artifact is renamed to include the version (from git tag) and platform architecture (e.g., `torrent_builder_v1.0.0_linux_amd64`)
- **macOS packaging**: Binaries are zipped before upload to match GitHub release artifact conventions
- **Release job**: Now depends on all three build jobs, downloads all artifacts into a unified `bin/` directory using `merge-multiple: true`, and publishes the complete set

## Verification
- [ ] Pipeline executed successfully
- [ ] No regressions in existing checks

## Breaking Changes
Release artifact naming and structure changed (single Linux binary → multi-platform binaries with version/arch suffixes). Any automation expecting the old artifact name will need updating.

## Related Issues
Closes #1