### PR TITLE
ci(release): add missing build dependencies for macOS and Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,7 @@ jobs:
           install: >-
             git
             base-devel
+            ${{ matrix.prefix }}-toolchain
             ${{ matrix.prefix }}-cmake
             ${{ matrix.prefix }}-libtorrent-rasterbar
             ${{ matrix.prefix }}-pkg-config
@@ -304,7 +305,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
-        run: brew install cmake libtorrent-rasterbar pkg-config
+        run: brew install boost cmake libtorrent-rasterbar pkg-config
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary

- Add `boost` to macOS `brew install` step — libtorrent-rasterbar headers require `boost/config.hpp`
- Add `${{ matrix.prefix }}-toolchain` to Windows MSYS2 packages — CMake could not locate the C++ compiler without the toolchain meta-package

The `v0.2.0-rc1` release workflow failed on macOS arm64 (`fatal error: 'boost/config.hpp' file not found`) and Windows amd64 (`No CMAKE_CXX_COMPILER could be found`). Both fixes address the root causes directly.