### PR TITLE
fix(build): resolve Windows compilation errors and macOS Boost headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ else()
     add_compile_options(-O2)
 endif()
 
+# Find Boost (required by libtorrent headers)
+find_package(Boost REQUIRED)
+
 # Find libtorrent
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBTORRENT REQUIRED libtorrent-rasterbar>=2.0.10)
@@ -65,6 +68,7 @@ add_executable(torrent_builder
 target_include_directories(torrent_builder PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${LIBTORRENT_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
 )
 
 # Add constants header

--- a/include/torrent_creator.hpp
+++ b/include/torrent_creator.hpp
@@ -15,7 +15,7 @@
 enum class LogLevel {
     INFO,
     WARNING,
-    ERROR
+    ERR
 };
 
 #include <thread>

--- a/src/torrent_creator.cpp
+++ b/src/torrent_creator.cpp
@@ -19,7 +19,7 @@ void log_message(const std::string& message, LogLevel level = LogLevel::INFO) {
     switch(level) {
         case LogLevel::INFO: level_str = "INFO"; break;
         case LogLevel::WARNING: level_str = "WARNING"; break;
-        case LogLevel::ERROR: level_str = "ERROR"; break;
+        case LogLevel::ERR: level_str = "ERROR"; break;
     }
     
     logfile << std::put_time(std::localtime(&now_time_t), "%Y-%m-%d %H:%M:%S") 
@@ -503,7 +503,7 @@ void TorrentCreator::create_torrent() {
         }
 
         if (ec) {
-            log_message("Error setting piece hashes: " + ec.message(), LogLevel::ERROR);
+            log_message("Error setting piece hashes: " + ec.message(), LogLevel::ERR);
             throw std::filesystem::filesystem_error("Error setting piece hashes: " + ec.message(), ec);
         }
 
@@ -559,7 +559,7 @@ void TorrentCreator::create_torrent() {
                 // Timeout after 30 seconds of no progress
                 if (elapsed.count() > 30 && !timeout_thrown && progress == 0) {
                     timeout_thrown = true;
-                    log_message("Hashing timeout after 30 seconds", LogLevel::ERROR);
+                    log_message("Hashing timeout after 30 seconds", LogLevel::ERR);
                     std::cout << "\n"; 
                     std::cerr << "Runtime error: Hashing timeout" << std::endl;
                     std::cerr.flush();
@@ -606,7 +606,7 @@ void TorrentCreator::create_torrent() {
 
         // If there was an error, throw an exception
         if (!error_message.empty()) {
-            log_message("Error during torrent creation: " + error_message, LogLevel::ERROR);
+            log_message("Error during torrent creation: " + error_message, LogLevel::ERR);
             throw std::runtime_error(error_message);
         }
 
@@ -628,13 +628,13 @@ void TorrentCreator::create_torrent() {
             log_message("Torrent created successfully: " + config_.output.string(), LogLevel::INFO);
             log_message("Torrent size: " + std::to_string(fs::file_size(config_.output)) + " bytes", LogLevel::INFO);
         } catch (const std::exception& e) {
-            log_message("Error saving torrent file: " + std::string(e.what()), LogLevel::ERROR);
+            log_message("Error saving torrent file: " + std::string(e.what()), LogLevel::ERR);
             throw;
         }
 
     } catch (const std::runtime_error& e) {
         std::cerr << e.what() << std::endl;
-        log_message("Runtime error: " + std::string(e.what()), LogLevel::ERROR);
+        log_message("Runtime error: " + std::string(e.what()), LogLevel::ERR);
         // Restore terminal settings if changed
         if (terminal_changed) {
             tcsetattr(STDIN_FILENO, TCSANOW, &old_tio);
@@ -642,7 +642,7 @@ void TorrentCreator::create_torrent() {
         throw;
     } catch (const std::exception& e) { // Catch-all for other standard exceptions
         std::cerr << "An unexpected error occurred: " << e.what() << std::endl;
-        log_message("Unexpected error: " + std::string(e.what()), LogLevel::ERROR);
+        log_message("Unexpected error: " + std::string(e.what()), LogLevel::ERR);
         // Restore terminal settings if changed
         if (terminal_changed) {
             tcsetattr(STDIN_FILENO, TCSANOW, &old_tio);

--- a/src/torrent_creator.cpp
+++ b/src/torrent_creator.cpp
@@ -4,8 +4,13 @@
 #include <iomanip>
 #include <chrono>
 #include <format>
+#ifndef _WIN32
 #include <unistd.h>
 #include <termios.h>
+#else
+#include <conio.h>
+#include <io.h>
+#endif
 
 // Logging function with levels
 void log_message(const std::string& message, LogLevel level = LogLevel::INFO) {
@@ -32,8 +37,32 @@ void log_message(const std::string& message, LogLevel level = LogLevel::INFO) {
 #include <ctime>
 #include <thread>
 #include <format>
-#include <stdexcept> // For std::runtime_error
-#include <system_error> // For std::error_code
+#include <stdexcept>
+#include <system_error>
+
+namespace {
+
+bool is_terminal() {
+#ifndef _WIN32
+    return isatty(STDIN_FILENO);
+#else
+    return _isatty(_fileno(stdin)) != 0;
+#endif
+}
+
+bool check_key_press(char& c) {
+#ifndef _WIN32
+    return read(STDIN_FILENO, &c, 1) > 0;
+#else
+    if (_kbhit()) {
+        c = static_cast<char>(_getch());
+        return true;
+    }
+    return false;
+#endif
+}
+
+}
 
 // Constructor for TorrentCreator
 TorrentCreator::TorrentCreator(const TorrentConfig& config)
@@ -173,12 +202,12 @@ void TorrentCreator::hash_block(const fs::path& path, lt::create_torrent& t, int
             
             // Check for user interruption
             char c = 0;
-            if (read(STDIN_FILENO, &c, 1) > 0) {
+            if (check_key_press(c)) {
                 if (c == 'q' || c == 'Q' || c == '\x03') {
                     log_message("Process interrupted by user", LogLevel::WARNING);
                     std::cerr << "\nProcess interrupted by user\n";
                     std::cerr.flush();
-                    std::exit(1); // Exit immediately
+                    std::exit(1);
                 }
             }
         }
@@ -261,12 +290,12 @@ void TorrentCreator::hash_large_file(const fs::path& path, lt::create_torrent& t
 
         // Non-blocking check for user input
         char c = 0;
-        if (read(STDIN_FILENO, &c, 1) > 0) {
+        if (check_key_press(c)) {
             if (c == 'q' || c == 'Q' || c == '\x03') {
                 log_message("Process interrupted by user", LogLevel::WARNING);
                 std::cerr << "\nProcess interrupted by user\n";
                 std::cerr.flush();
-                std::exit(1); // Exit immediately instead of throwing exception
+                std::exit(1);
             }
         }
         // --- End of timeout and user interruption check ---
@@ -340,33 +369,29 @@ std::string TorrentCreator::format_eta(double eta) const {
 
 // Creates the torrent file
 // Function to restore terminal settings on program exit
+#ifndef _WIN32
 void cleanup_terminal(struct termios* old_settings) {
     if (old_settings && isatty(STDIN_FILENO)) {
         tcsetattr(STDIN_FILENO, TCSANOW, old_settings);
     }
 }
+#endif
 
 void TorrentCreator::create_torrent() {
-    // Set up terminal for non-blocking input
-    struct termios old_tio, new_tio;
     bool terminal_changed = false;
+#ifndef _WIN32
+    struct termios old_tio, new_tio;
     
-    // Only change terminal settings if stdin is a terminal
-    if (isatty(STDIN_FILENO)) {
-        // Get current terminal settings
+    if (is_terminal()) {
         tcgetattr(STDIN_FILENO, &old_tio);
-        // Make a copy
         new_tio = old_tio;
-        // Disable canonical mode and echo
         new_tio.c_lflag &= (~ICANON & ~ECHO);
-        // Set minimum number of characters for non-canonical read
         new_tio.c_cc[VMIN] = 0;
-        // Set timeout to 0.1 seconds
         new_tio.c_cc[VTIME] = 1;
-        // Apply new settings
         tcsetattr(STDIN_FILENO, TCSANOW, &new_tio);
         terminal_changed = true;
     }
+#endif
     
     try {
         log_message("Starting torrent creation for: " + config_.path.string(), LogLevel::INFO);
@@ -474,12 +499,12 @@ void TorrentCreator::create_torrent() {
             
             // Check for user interruption
             char c = 0;
-            if (read(STDIN_FILENO, &c, 1) > 0) {
+            if (check_key_press(c)) {
                 if (c == 'q' || c == 'Q' || c == '\x03') {
                     log_message("Process interrupted by user", LogLevel::WARNING);
                     std::cerr << "\nProcess interrupted by user\n";
                     std::cerr.flush();
-                    std::exit(1); // Exit immediately
+                    std::exit(1);
                 }
             }
         };
@@ -520,25 +545,20 @@ void TorrentCreator::create_torrent() {
         }
 
         // Set up non-blocking input for interruption
-        struct termios old_tio, new_tio;
-        bool terminal_changed = false;
+#ifndef _WIN32
+        struct termios old_tio_inner, new_tio_inner;
+        bool inner_terminal_changed = false;
         
-        // Only change terminal settings if stdin is a terminal
         if (isatty(STDIN_FILENO)) {
-            // Get current terminal settings
-            tcgetattr(STDIN_FILENO, &old_tio);
-            // Make a copy
-            new_tio = old_tio;
-            // Disable canonical mode and echo
-            new_tio.c_lflag &= (~ICANON & ~ECHO);
-            // Set minimum number of characters for non-canonical read
-            new_tio.c_cc[VMIN] = 0;
-            // Set timeout to 0 seconds (non-blocking)
-            new_tio.c_cc[VTIME] = 0;
-            // Apply new settings
-            tcsetattr(STDIN_FILENO, TCSANOW, &new_tio);
-            terminal_changed = true;
+            tcgetattr(STDIN_FILENO, &old_tio_inner);
+            new_tio_inner = old_tio_inner;
+            new_tio_inner.c_lflag &= (~ICANON & ~ECHO);
+            new_tio_inner.c_cc[VMIN] = 0;
+            new_tio_inner.c_cc[VTIME] = 0;
+            tcsetattr(STDIN_FILENO, TCSANOW, &new_tio_inner);
+            inner_terminal_changed = true;
         }
+#endif
         
         // Check for user interruption and timeout
         auto loop_start_time = std::chrono::steady_clock::now();
@@ -564,24 +584,28 @@ void TorrentCreator::create_torrent() {
                     std::cerr << "Runtime error: Hashing timeout" << std::endl;
                     std::cerr.flush();
                     
+#ifndef _WIN32
                     if (terminal_changed) {
                         tcsetattr(STDIN_FILENO, TCSANOW, &old_tio);
                     }
+#endif
                     
                     std::exit(1);
                 }
 
                 // Check for user interruption
                 char c = 0;
-                if (read(STDIN_FILENO, &c, 1) > 0) {
+                if (check_key_press(c)) {
                     if (c == 'q' || c == 'Q' || c == '\x03') {
                         log_message("Process interrupted by user", LogLevel::WARNING);
                         std::cerr << "\nProcess interrupted by user" << std::endl;
                         std::cerr.flush();
                         
+#ifndef _WIN32
                         if (terminal_changed) {
                             tcsetattr(STDIN_FILENO, TCSANOW, &old_tio);
                         }
+#endif
                         
                         std::exit(1);
                     }
@@ -635,25 +659,28 @@ void TorrentCreator::create_torrent() {
     } catch (const std::runtime_error& e) {
         std::cerr << e.what() << std::endl;
         log_message("Runtime error: " + std::string(e.what()), LogLevel::ERR);
-        // Restore terminal settings if changed
+#ifndef _WIN32
         if (terminal_changed) {
             tcsetattr(STDIN_FILENO, TCSANOW, &old_tio);
         }
+#endif
         throw;
-    } catch (const std::exception& e) { // Catch-all for other standard exceptions
+    } catch (const std::exception& e) {
         std::cerr << "An unexpected error occurred: " << e.what() << std::endl;
         log_message("Unexpected error: " + std::string(e.what()), LogLevel::ERR);
-        // Restore terminal settings if changed
+#ifndef _WIN32
         if (terminal_changed) {
             tcsetattr(STDIN_FILENO, TCSANOW, &old_tio);
         }
+#endif
         throw;
     }
     
-    // Restore terminal settings if changed
+#ifndef _WIN32
     if (terminal_changed) {
         tcsetattr(STDIN_FILENO, TCSANOW, &old_tio);
     }
+#endif
 }
 
 // Prints a summary of the created torrent


### PR DESCRIPTION
## Summary
Fixes compilation failures on Windows (MSYS2) and macOS by addressing missing headers, macro collisions, and POSIX-only API usage.

## Bug Description
- **Windows:** `ERROR` macro from `<windows.h>` collided with `LogLevel::ERROR` enum, and `termios.h`/`unistd.h` are unavailable
- **macOS:** CMakeLists.txt didn't propagate Boost include directories

## Changes Made
- Rename `LogLevel::ERROR` to `LogLevel::ERR` to avoid Windows macro collision
- Add `find_package(Boost REQUIRED)` and `${Boost_INCLUDE_DIRS}` to CMakeLists.txt
- Add `#ifndef _WIN32` guards around all `termios`/`tcsetattr`/`tcgetattr` usage
- Implement Windows alternatives using `_kbhit()`/`_getch()` from `<conio.h>`
- Add `is_terminal()` and `check_key_press()` helper functions with platform-specific implementations

## Testing
- [x] All 6 platform builds pass (Linux amd64/arm64, Windows amd64/arm64, macOS arm64/amd64)

## Related Issues
Related to #13