### PR TITLE
fix(test): make exec_command cross-platform for Windows builds

### DIFF
--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -21,7 +21,11 @@ std::string exec_command(const std::string& cmd, int& exit_code) {
         result += buffer.data();
     }
     int status = pclose(pipe);
+#ifdef _WIN32
+    exit_code = status;
+#else
     exit_code = WEXITSTATUS(status);
+#endif
     return result;
 }
 


### PR DESCRIPTION
## Summary
Fix Windows build failure in release workflow caused by `WEXITSTATUS`, a POSIX macro unavailable on Windows/MinGW.

## Bug Description
- **What was happening:** Windows builds (UCRT64 amd64, CLANGARM64 arm64) failed at compile time with `'WEXITSTATUS' was not declared in this scope` in `tests/test_cli.cpp:24`
- **Expected behavior:** All platform builds (Linux, macOS, Windows) compile and produce release artifacts
- **Root cause:** `WEXITSTATUS` is a POSIX macro from `<sys/wait.h>` that doesn't exist in the Windows CRT. On Windows, `pclose()` returns the exit code directly — no wait-status decoding needed
- **When introduced:** Commit `1a33ed3` (Apr 18, 2026) — the first CLI integration test file. Unnoticed because v0.3.0 was the first release with Windows builds

## Changes Made
- Added `#ifdef _WIN32` guard in `exec_command()` to use `status` directly on Windows and `WEXITSTATUS(status)` on POSIX

## Testing
- [x] Build compiles on Linux (verified locally)
- [x] No behavioral change on Linux/macOS (code path unchanged)
- [ ] Windows build will be verified via CI

## Breaking Changes
None