### PR TITLE
ci: add multi-platform build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,115 @@
+name: Build and Test
+
+on:
+  push:
+    tags-ignore: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: build-and-test-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-linux:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libboost-dev libtorrent-rasterbar-dev pkg-config
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test
+        run: cd build && ctest --output-on-failure --no-tests=error
+
+  build-windows:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            arch: amd64
+            msystem: UCRT64
+            prefix: mingw-w64-ucrt-x86_64
+          - os: windows-11-arm
+            arch: arm64
+            msystem: CLANGARM64
+            prefix: mingw-w64-clang-aarch64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >-
+            git
+            base-devel
+            ${{ matrix.prefix }}-toolchain
+            ${{ matrix.prefix }}-cmake
+            ${{ matrix.prefix }}-libtorrent-rasterbar
+            ${{ matrix.prefix }}-pkg-config
+
+      - name: Configure
+        shell: msys2 {0}
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -G "MSYS Makefiles"
+
+      - name: Build
+        shell: msys2 {0}
+        run: cmake --build build --parallel
+
+      - name: Test
+        shell: msys2 {0}
+        run: cd build && ctest --output-on-failure --no-tests=error
+
+  build-macos:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+          - os: macos-15-intel
+            arch: amd64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: brew install boost cmake libtorrent-rasterbar pkg-config
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test
+        run: cd build && ctest --output-on-failure --no-tests=error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release -DTORRENT_BUILDER_VERSION=${{ steps.version.outputs.VERSION }}
-          cmake --build .
+          cmake --build . --parallel
 
       - name: Rename binary
         run: mv build/torrent_builder torrent_builder_${{ steps.version.outputs.VERSION }}_linux_${{ matrix.arch }}
@@ -317,7 +317,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release -G "MSYS Makefiles" -DTORRENT_BUILDER_VERSION=${{ steps.version.outputs.VERSION }}
-          cmake --build .
+          cmake --build . --parallel
 
       - name: Rename binary
         shell: bash
@@ -336,7 +336,7 @@ jobs:
         include:
           - os: macos-latest
             arch: arm64
-          - os: macos-15
+          - os: macos-15-intel
             arch: amd64
     runs-on: ${{ matrix.os }}
     steps:
@@ -354,7 +354,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release -DTORRENT_BUILDER_VERSION=${{ steps.version.outputs.VERSION }}
-          cmake --build .
+          cmake --build . --parallel
 
       - name: Rename and package
         run: |


### PR DESCRIPTION
## Summary

Adds a comprehensive multi-platform CI workflow that builds and tests the project across 6 platforms (Linux, Windows, and macOS on both amd64 and arm64 architectures), and fixes a critical runner misconfiguration in the release workflow.

## Motivation

The project previously lacked automated cross-platform verification, risking platform-specific bugs going undetected. Additionally, the release workflow incorrectly used `macos-15` (ARM64) for AMD64 builds, which would produce incorrect binaries. This PR establishes continuous integration coverage across all supported platforms and corrects the release pipeline.

## Changes Made

- **New workflow** — `.github/workflows/build-and-test.yml`:
  - Triggers on all pushes, pull requests, and manual workflow_dispatch
  - Excludes tag pushes matching `v*` (release tags handled separately)
  - Implements concurrency control with `cancel-in-progress` to avoid redundant runs
  - Runs 6 matrix jobs across 3 OS families:
    - **Linux**: `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64)
    - **Windows**: `windows-latest` (amd64, MSYS2 UCRT64) and `windows-11-arm` (arm64, MSYS2 CLANGARM64)
    - **macOS**: `macos-latest` (arm64) and `macos-15-intel` (amd64)
  - Each job installs dependencies (Boost, CMake, libtorrent-rasterbar, pkg-config), configures with CMake Debug builds, builds with `--parallel`, and runs tests via `ctest --output-on-failure --no-tests=error`
  - Uses `persist-credentials: false` on checkout for security
  - Sets `permissions: contents: read` (least-privilege)

- **Release workflow fixes** — `.github/workflows/release.yml`:
  - Corrected macOS AMD64 runner from `macos-15` → `macos-15-intel` to match actual hardware architecture
  - Added `--parallel` flag to all CMake build commands (Linux, Windows, macOS) to accelerate release builds

## Testing
- [ ] Pipeline executed successfully
- [ ] No regressions in existing checks

## Breaking Changes

None — This change is purely CI/CD infrastructure. No user-facing API, behavior, or configuration changes.