### PR TITLE
feat(cli): add --name flag to set custom torrent name

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For an optimized Release build: `cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --
   -o, --output arg           Output torrent file path (optional; auto-generated if omitted)
   -t, --torrent-version arg  Torrent version (1=v1, 2=v2, 3=hybrid) (default: 3)
   --comment arg              Torrent comment
+  -n, --name arg             Set custom torrent name (overrides default inferred from path)
   --private                  Make torrent private
   --default-trackers         Use default trackers
   -T, --tracker arg          Add tracker URL (can be used multiple times)

--- a/include/torrent_creator.hpp
+++ b/include/torrent_creator.hpp
@@ -46,6 +46,7 @@ struct TorrentConfig {
     std::vector<std::string> web_seeds; // List of web seed URLs
     std::optional<int> piece_size;    // Optional piece size in bytes
     std::optional<std::string> creator; // Optional creator string
+    std::optional<std::string> name;       // Optional custom torrent name (overrides default inferred from path)
     bool include_creation_date;       // Flag to include creation date
 
 
@@ -54,10 +55,12 @@ struct TorrentConfig {
     TorrentConfig(fs::path p, fs::path o, std::vector<std::string> t,
                  TorrentVersion v, std::optional<std::string> c = std::nullopt,
                  bool priv = false, std::vector<std::string> ws = {}, std::optional<int> ps = std::nullopt,
-                 std::optional<std::string> creator = std::nullopt, bool include_creation_date = false) // Add new parameters with default values
+                 std::optional<std::string> creator = std::nullopt,
+                 std::optional<std::string> name_val = std::nullopt,
+                 bool include_creation_date = false)
         : path(p), output(o), trackers(t), version(v),
           comment(c), is_private(priv), web_seeds(ws), piece_size(ps),
-          creator(creator), include_creation_date(include_creation_date) // Initialize new members
+          creator(creator), name(name_val), include_creation_date(include_creation_date)
     {
         // Validate that the provided path exists
         std::error_code ec;

--- a/src/torrent_builder.cpp
+++ b/src/torrent_builder.cpp
@@ -380,6 +380,23 @@ get_version: // Label to jump to if overwrite is 'n' or empty
         }
     }
 
+    // Get optional custom torrent name
+    std::optional<std::string> torrent_name = std::nullopt;
+    while (true) {
+        std::string input_name;
+        std::cout << "Custom torrent name (leave blank for default): ";
+        std::getline(std::cin, input_name);
+        if (input_name.empty()) {
+            break;
+        }
+        if (input_name.find_first_not_of(" \t\n\r") == std::string::npos) {
+            std::cout << "Error: Name cannot be whitespace-only\n";
+            continue;
+        }
+        torrent_name = input_name;
+        break;
+    }
+
     // Get creation date
     bool include_creation_date = false;
     while (true)
@@ -404,8 +421,8 @@ get_version: // Label to jump to if overwrite is 'n' or empty
 
     return TorrentConfig(path, output, trackers, tv,
                          comment.empty() ? std::nullopt : std::optional<std::string>(comment),
-                         is_private, web_seeds, piece_size, creator_str, include_creation_date
-
+                         is_private, web_seeds, piece_size, creator_str, torrent_name,
+                         include_creation_date
     );
 }
 
@@ -518,6 +535,15 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
         comment = result["comment"].as<std::string>();
     }
 
+    // Get optional torrent name
+    std::optional<std::string> torrent_name = std::nullopt;
+    if (result.count("name")) {
+        torrent_name = result["name"].as<std::string>();
+        if (torrent_name->find_first_not_of(" \t\n\r") == std::string::npos) {
+            throw std::runtime_error("Torrent name cannot be empty or whitespace-only");
+        }
+    }
+
     // Get web seeds
     std::vector<std::string> web_seeds;
     if (result.count("webseed"))
@@ -570,12 +596,9 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
 
     try
     {
-        return TorrentConfig(input_path,
-                             output_path,
-                             trackers,
-                             tv, comment, result.count("private"), web_seeds, piece_size,
-                             creator_str,          // Pass creator string
-                             include_creation_date // Pass creation date flag
+        return TorrentConfig(input_path, output_path, trackers, tv,
+                             comment, result.count("private") > 0, web_seeds, piece_size,
+                             creator_str, torrent_name, include_creation_date
         );
     }
     catch (const fs::filesystem_error &e)
@@ -680,6 +703,7 @@ int main(int argc, char *argv[])
             "t,torrent-version", "Torrent version (1=v1, 2=v2, 3=hybrid)",
             cxxopts::value<std::string>()->default_value("3"),
             "{1,2,3}")("c,comment", "Torrent comment", cxxopts::value<std::string>(), "COMMENT")(
+            "n,name", "Set custom torrent name", cxxopts::value<std::string>(), "NAME")(
             "private", "Make torrent private")("default-trackers", "Use default trackers")(
             "T,tracker", "Add tracker URL", cxxopts::value<std::vector<std::string>>(), "URL")(
             "w,webseed", "Add web seed URL", cxxopts::value<std::vector<std::string>>(),

--- a/src/torrent_creator.cpp
+++ b/src/torrent_creator.cpp
@@ -499,6 +499,11 @@ void TorrentCreator::create_torrent() {
             }
 
             lt::entry e = t.generate();
+
+            // Set custom name if provided
+            if (config_.name) {
+                e["info"]["name"] = *config_.name;
+            }
             lt::bencode(std::ostream_iterator<char>(out), e);
 
             if (!out) {

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -6,6 +6,7 @@
 #include <regex>
 #include <filesystem>
 #include <fstream>
+#include "torrent_inspector.hpp"
 
 namespace {
 
@@ -826,3 +827,234 @@ TEST(CLI, OutputDirCreatePermissionDeniedFails) {
     fs::remove_all(temp_dir, ec);
 }
 #endif
+
+TEST(CLI, NameFlagSetsTorrentName) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_name_flag_test";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    auto output_file = temp_dir / "output.torrent";
+    { std::ofstream(input_file) << "test content for name flag"; }
+
+    std::string cmd = get_binary_path() + " --path " + input_file.string()
+        + " --output " + output_file.string()
+        + " --name \"Custom.Torrent.Name\""
+        + " --torrent-version 1 2>&1";
+
+    int exit_code;
+    std::string output = exec_command(cmd, exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_TRUE(fs::exists(output_file)) << "Torrent file not created";
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_EQ(meta.name, "Custom.Torrent.Name")
+        << "Torrent internal name should match --name value";
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, NameFlagIndependentOfOutput) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_name_independent_test";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "MyFile.txt";
+    auto output_file = temp_dir / "OtherName.torrent";
+    { std::ofstream(input_file) << "test content"; }
+
+    std::string cmd = get_binary_path() + " --path " + input_file.string()
+        + " --output " + output_file.string()
+        + " --name \"Internal.Name\""
+        + " --torrent-version 1 2>&1";
+
+    int exit_code;
+    std::string output = exec_command(cmd, exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_EQ(meta.name, "Internal.Name");
+
+    EXPECT_TRUE(fs::exists(output_file))
+        << "Output file should be OtherName.torrent, not named after --name";
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, NameFlagWithDirectory) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_name_dir_test";
+    auto content_dir = temp_dir / "MyFolder";
+    fs::create_directories(content_dir);
+    { std::ofstream(content_dir / "file1.txt") << "content1"; }
+    { std::ofstream(content_dir / "file2.txt") << "content2"; }
+    auto output_file = temp_dir / "output.torrent";
+
+    std::string cmd = get_binary_path() + " --path " + content_dir.string()
+        + " --output " + output_file.string()
+        + " --name \"Dir.Custom.Name\""
+        + " --torrent-version 1 2>&1";
+
+    int exit_code;
+    std::string output = exec_command(cmd, exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_EQ(meta.name, "Dir.Custom.Name")
+        << "Name should override directory name";
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, DefaultNameUnchanged) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_default_name_test";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "OriginalName.txt";
+    auto output_file = temp_dir / "output.torrent";
+    { std::ofstream(input_file) << "test content"; }
+
+    std::string cmd = get_binary_path() + " --path " + input_file.string()
+        + " --output " + output_file.string()
+        + " --torrent-version 1 2>&1";
+
+    int exit_code;
+    std::string output = exec_command(cmd, exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_EQ(meta.name, "OriginalName.txt")
+        << "Default name should be inferred from filename";
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, EmptyNameRejected) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_empty_name_test";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    { std::ofstream(input_file) << "test content"; }
+
+    std::string cmd = get_binary_path() + " --path " + input_file.string()
+        + " --output " + (temp_dir / "output.torrent").string()
+        + " --name \"   \""
+        + " --torrent-version 1 2>&1";
+
+    int exit_code;
+    std::string output = exec_command(cmd, exit_code);
+
+    EXPECT_NE(exit_code, 0) << "Should fail with whitespace-only name";
+    EXPECT_NE(output.find("cannot be empty"), std::string::npos)
+        << "Error message should mention empty name. Output: " << output;
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, NameFlagWithV2Directory) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_name_v2_dir_test";
+    auto content_dir = temp_dir / "MyFolder";
+    fs::create_directories(content_dir);
+    { std::ofstream(content_dir / "file1.txt") << "content1"; }
+    { std::ofstream(content_dir / "file2.txt") << "content2"; }
+    auto output_file = temp_dir / "output.torrent";
+
+    std::string cmd = get_binary_path() + " --path " + content_dir.string()
+        + " --output " + output_file.string()
+        + " --name \"V2.Custom.Name\""
+        + " --torrent-version 2 2>&1";
+
+    int exit_code;
+    std::string output = exec_command(cmd, exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_EQ(meta.name, "V2.Custom.Name")
+        << "V2 torrent internal name should match --name value";
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, NameFlagWithHybridDirectory) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_name_hybrid_dir_test";
+    auto content_dir = temp_dir / "MyFolder";
+    fs::create_directories(content_dir);
+    { std::ofstream(content_dir / "file1.txt") << "content1"; }
+    { std::ofstream(content_dir / "file2.txt") << "content2"; }
+    auto output_file = temp_dir / "output.torrent";
+
+    std::string cmd = get_binary_path() + " --path " + content_dir.string()
+        + " --output " + output_file.string()
+        + " --name \"Hybrid.Custom.Name\""
+        + " --torrent-version 3 2>&1";
+
+    int exit_code;
+    std::string output = exec_command(cmd, exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_EQ(meta.name, "Hybrid.Custom.Name")
+        << "Hybrid torrent internal name should match --name value";
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, InteractiveNamePrompt) {
+#ifdef _WIN32
+    GTEST_SKIP() << "stdin piping via popen() is unreliable on Windows";
+#endif
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_interactive_name_test";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    auto output_file = temp_dir / "output.torrent";
+    { std::ofstream(input_file) << "test content"; }
+
+    std::string inputs =
+        "'" + input_file.string() + "' "   // path
+        "'" + output_file.string() + "' "  // output
+        "1 "                               // version (v1)
+        "'' "                              // comment (empty)
+        "n "                               // private? no
+        "n "                               // default trackers? no
+        "n "                               // custom trackers? no
+        "'' "                              // web seed (empty/finish)
+        "n "                               // custom piece size? no
+        "n "                               // creator? no
+        "'My.Interactive.Name' "           // custom name
+        "n ";                              // creation date? no
+
+    std::string cmd = "printf '%s\\n' " + inputs + "| " + get_binary_path() + " --interactive 2>&1";
+
+    int exit_code;
+    std::string output = exec_command(cmd, exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_EQ(meta.name, "My.Interactive.Name")
+        << "Interactive mode should apply custom name";
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}


### PR DESCRIPTION
## Summary
Adds a `--name` / `-n` CLI flag to set a custom torrent name, overriding the default name inferred from the input path or directory. Includes validation to reject empty or whitespace-only names and supports both command-line and interactive modes.

## Motivation
Previously, the torrent internal name was always derived from the input file or directory name. Users needed the flexibility to specify an arbitrary torrent name (e.g., for distribution with a specific title) without renaming files or relying on the output filename, which is separate from the torrent metadata.

## Changes Made
- **TorrentConfig struct** (`include/torrent_creator.hpp`): Added `std::optional<std::string> name` field and updated constructor to accept and store the custom name.
- **CLI parsing** (`src/torrent_builder.cpp`): Implemented `--name/-n` option with validation that rejects empty or whitespace-only values; added interactive prompt for custom name with identical validation.
- **Torrent generation** (`src/torrent_creator.cpp`): When a custom name is provided, set `e["info"]["name"]` in the torrent metadata before bencoding.
- **Documentation** (`README.md`): Added the new `-n, --name` entry to the CLI options table.
- **Tests** (`tests/test_cli.cpp`): Added 8 end-to-end tests covering name flag behavior across v1/v2/hybrid torrents, single files and directories, default preservation, empty/whitespace rejection, and interactive prompt.

## Testing
- [x] Tested locally
- [x] Unit tests added
- [x] Documentation updated

## Breaking Changes
**ABI note:** `TorrentConfig` struct gains a new `std::optional<std::string> name` field. Source-compatible (default parameter), but downstream consumers must recompile against updated headers. No behavioral break — feature is opt-in.

## Related Issues
Closes #33