### PR TITLE
feat(cli): add --verbose, --quiet, and --json output modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(torrent_builder_core STATIC
     src/logger.cpp
     src/utils.cpp
     src/terminal.cpp
+    src/output.cpp
 )
 
 target_include_directories(torrent_builder_core PUBLIC

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The **Torrent Builder** is a command-line tool for creating torrent files, offer
 - Include comments in torrent metadata
 - Cross-seeding support: source field and info hash randomization
 - Detailed summary output after creation
+- Verbose mode for detailed creation diagnostics
+- Quiet mode for scripts and CI pipelines
+- JSON output for programmatic consumption
 - Auto-naming: output filename generated from tracker domain and content name
 - Collision-safe naming: automatically resolves filename conflicts with `(1)`, `(2)`, etc.
 - Filename truncation with UTF-8 boundary safety (255-byte filesystem limit)
@@ -91,6 +94,9 @@ For an optimized Release build: `cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --
 ```
   -h, --help                 Show help
   -v, --version              Show version
+  --verbose                  Enable verbose output (conflicts with --quiet, --json)
+  -q, --quiet                Suppress non-essential output, auto-decline prompts (conflicts with --verbose)
+  --json                     Output torrent metadata as JSON (implies --quiet, conflicts with --verbose)
   -i, --interactive          Run in interactive mode
   -p, --path arg             Path to file or directory (required)
   -o, --output arg           Output torrent file path (optional; auto-generated if omitted)
@@ -112,6 +118,32 @@ For an optimized Release build: `cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --
       --output-dir DIR       Directory for auto-generated output filename (created if needed)
       --tracker-index N      Index of tracker to use for filename prefix (0-based, default: 0)
 ```
+
+> **Note:** `--verbose`, `--quiet`, and `--json` are ignored in interactive mode. In CLI mode, `--verbose` and `--quiet` are mutually exclusive, as are `--verbose` and `--json`. The `--json` flag implies `--quiet` and auto-declines any overwrite prompts.
+
+### JSON Output Format
+
+When using `--json`, the output is a single JSON object to stdout (errors go to stderr):
+
+```json
+{
+  "name": "filename",
+  "info_hash_v1": "...",
+  "info_hash_v2": "...",
+  "is_hybrid": false,
+  "total_size": 12345678,
+  "piece_length": 262144,
+  "piece_count": 48,
+  "files_count": 1,
+  "is_private": false,
+  "trackers": ["https://tracker.example/announce"],
+  "web_seeds": [],
+  "magnet_link": "...",
+  "output_path": "/path/to/output.torrent"
+}
+```
+
+Optional fields (`comment`, `creation_date`, `created_by`, `source`, `entropy`) appear only when present in the torrent metadata.
 
 > **Note:** `--version` now shows the software version. For torrent format version, use `--torrent-version` or `-t`.
 
@@ -222,6 +254,18 @@ Include only specific file types:
 ```
 
 > **Note:** `--include` patterns take precedence over `--exclude` when both match. Glob syntax: `*` (any non-slash), `**/` (zero or more dirs), `**` (any path), `?` (single char). Matching is case-insensitive.
+
+Verbose, quiet, and JSON output:
+```bash
+./torrent_builder --path /data/file --output file.torrent --verbose
+# Shows extra detail: file count, piece size reasoning, tracker tiers
+
+./torrent_builder --path /data/file --output file.torrent --quiet
+# Suppresses progress bar and summary; errors still shown
+
+./torrent_builder --path /data/file --output file.torrent --json
+# Outputs torrent metadata as JSON to stdout (useful for scripting)
+```
 
 Inspect torrent metadata:
 ```bash

--- a/include/output.hpp
+++ b/include/output.hpp
@@ -1,0 +1,91 @@
+#ifndef OUTPUT_HPP
+#define OUTPUT_HPP
+
+#include <string>
+#include <cstdint>
+
+/**
+ * Console output verbosity levels.
+ *
+ * - QUIET:   Only errors (stderr). Used for scripts/CI and JSON mode.
+ * - NORMAL:  Default: progress bar + summary + info messages.
+ * - VERBOSE: Extra detail: piece size reasoning, file discovery, tracker tiers.
+ */
+enum class Verbosity {
+    QUIET,
+    NORMAL,
+    VERBOSE
+};
+
+/**
+ * @brief Set the global console verbosity level.
+ * @param level QUIET, NORMAL, or VERBOSE.
+ */
+void set_verbosity(Verbosity level);
+
+/**
+ * @brief Get the current global verbosity level.
+ * @return Current Verbosity level.
+ */
+Verbosity get_verbosity();
+
+/**
+ * @brief Enable or disable JSON output mode.
+ *
+ * When enabled, suppresses all human-readable console output so that
+ * only the final JSON object is written to stdout.
+ *
+ * @param enabled true to enable JSON mode.
+ */
+void set_json_mode(bool enabled);
+
+/**
+ * @brief Check whether JSON output mode is active.
+ * @return true if JSON mode is enabled.
+ */
+bool is_json_mode();
+
+/**
+ * @brief Print an informational message to stdout.
+ *
+ * Suppressed in QUIET and JSON modes.
+ *
+ * @param msg The message to print.
+ */
+void print_info(const std::string& msg);
+
+/**
+ * @brief Print a verbose diagnostic message to stdout.
+ *
+ * Only printed when verbosity is VERBOSE.
+ *
+ * @param msg The message to print.
+ */
+void print_verbose(const std::string& msg);
+
+/**
+ * @brief Print an error message to stderr.
+ *
+ * Always printed regardless of verbosity or JSON mode.
+ *
+ * @param msg The error message to print.
+ */
+void print_error(const std::string& msg);
+
+/**
+ * @brief Print a progress bar to stdout.
+ *
+ * Displays an ASCII progress bar with percentage, processed/total size,
+ * hashing speed, and ETA. Suppressed in QUIET and JSON modes.
+ *
+ * @param progress    Number of pieces completed.
+ * @param total       Total number of pieces.
+ * @param speed       Hashing speed in bytes per second.
+ * @param eta         Estimated time remaining in seconds.
+ * @param processed   Bytes processed so far.
+ * @param total_size  Total bytes to process.
+ */
+void print_progress(int progress, int total, double speed, double eta,
+                    int64_t processed, int64_t total_size);
+
+#endif

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1,0 +1,45 @@
+#include "output.hpp"
+#include "utils.hpp"
+#include <iostream>
+#include <cmath>
+
+static Verbosity g_verbosity = Verbosity::NORMAL;
+static bool g_json_mode = false;
+
+void set_verbosity(Verbosity level) { g_verbosity = level; }
+Verbosity get_verbosity() { return g_verbosity; }
+void set_json_mode(bool enabled) { g_json_mode = enabled; }
+bool is_json_mode() { return g_json_mode; }
+
+void print_info(const std::string& msg) {
+    if (g_verbosity == Verbosity::QUIET || g_json_mode) return;
+    std::cout << msg;
+}
+
+void print_verbose(const std::string& msg) {
+    if (g_verbosity != Verbosity::VERBOSE) return;
+    std::cout << msg;
+}
+
+void print_error(const std::string& msg) {
+    std::cerr << msg;
+}
+
+void print_progress(int progress, int total, double speed, double eta,
+                    int64_t processed, int64_t total_size) {
+    if (g_verbosity == Verbosity::QUIET || g_json_mode) return;
+
+    const int bar_width = 50;
+    float pct = static_cast<float>(progress) / total;
+    int filled = static_cast<int>(std::round(bar_width * pct));
+
+    std::cout << "[";
+    for (int i = 0; i < bar_width; ++i) {
+        std::cout << (i < filled ? "=" : " ");
+    }
+    std::cout << "] " << static_cast<int>(pct * 100) << "% ";
+    std::cout << utils::format_size(processed) << " / " << utils::format_size(total_size) << " ";
+    std::cout << "Speed: " << utils::format_speed(speed) << " ";
+    std::cout << "ETA: " << utils::format_eta(eta) << "\r";
+    std::cout.flush();
+}

--- a/src/torrent_builder.cpp
+++ b/src/torrent_builder.cpp
@@ -13,6 +13,7 @@
 #include <ranges>
 #include <stdexcept>
 #include "torrent_inspector.hpp"
+#include "output.hpp"
 
 namespace fs = std::filesystem;
 
@@ -70,6 +71,10 @@ std::optional<std::string> prompt_optional_string(const std::string &prompt_text
 
 OverwriteDecision prompt_overwrite(const std::string &filepath)
 {
+    if (get_verbosity() == Verbosity::QUIET || is_json_mode())
+    {
+        return OverwriteDecision::Declined;
+    }
     while (true)
     {
         std::string overwrite;
@@ -91,18 +96,18 @@ OverwriteDecision prompt_overwrite(const std::string &filepath)
 // Get torrent configuration from user input (interactive mode)
 TorrentConfig get_interactive_config()
 {
-    std::cout << "=== TORRENT CONFIGURATION ===" << std::endl;
+    print_info("=== TORRENT CONFIGURATION ===\n");
 
     // Get input path
     std::string path;
     while (true)
     {
-        std::cout << "Path to file or directory: ";
+        print_info("Path to file or directory: ");
         std::getline(std::cin, path);
         path = utils::sanitize_path(path);
         if (path.empty())
         {
-            std::cout << "Error: Input path cannot be empty\n";
+            print_info("Error: Input path cannot be empty\n");
             continue;
         }
         try
@@ -110,22 +115,22 @@ TorrentConfig get_interactive_config()
             // Check if the path exists
             if (!fs::exists(path))
             {
-                std::cout << "Error: The specified path does not exist. Please check the path and "
-                             "try again.\n";
+                print_info("Error: The specified path does not exist. Please check the path and "
+                             "try again.\n");
                 continue;
             }
             // Check if we have read permissions
             fs::file_status status = fs::status(path);
             if ((status.permissions() & fs::perms::owner_read) == fs::perms::none)
             {
-                std::cout << "Error: No read permissions for path\n";
+                print_info("Error: No read permissions for path\n");
                 continue;
             }
             break;
         }
         catch (const fs::filesystem_error &e)
         {
-            std::cout << "Filesystem error: " << e.what() << "\n";
+            print_info(std::string("Filesystem error: ") + e.what() + "\n");
             continue;
         }
     }
@@ -134,18 +139,18 @@ TorrentConfig get_interactive_config()
     std::string output;
     while (true)
     {
-        std::cout << "Path to save torrent: ";
+        print_info("Path to save torrent: ");
         std::getline(std::cin, output);
         output = utils::sanitize_path(output);
         if (output.empty())
         {
-            std::cout << "Error: Output path cannot be empty\n";
+            print_info("Error: Output path cannot be empty\n");
             continue;
         }
         // 8 is the minimum length that can carry ".torrent" suffix
         if (output.size() < 8 || output.substr(output.size() - 8) != ".torrent")
         {
-            std::cout << "Error: Output path must end with '.torrent'\n";
+            print_info("Error: Output path must end with '.torrent'\n");
             continue;
         }
 
@@ -164,21 +169,21 @@ TorrentConfig get_interactive_config()
             fs::path parent_dir = fs::path(output).parent_path();
             if (!parent_dir.empty() && !fs::exists(parent_dir))
             {
-                std::cout << "Error: Parent directory does not exist\n";
+                print_info("Error: Parent directory does not exist\n");
                 continue;
             }
             // Check write permissions
             fs::file_status status = fs::status(parent_dir);
             if ((status.permissions() & fs::perms::owner_write) == fs::perms::none)
             {
-                std::cout << "Error: No write permissions for directory\n";
+                print_info("Error: No write permissions for directory\n");
                 continue;
             }
             break;
         }
         catch (const fs::filesystem_error &e)
         {
-            std::cout << "Filesystem error: " << e.what() << "\n";
+            print_info(std::string("Filesystem error: ") + e.what() + "\n");
             continue;
         }
     }
@@ -189,7 +194,7 @@ get_version: // Label to jump to if overwrite is 'n' or empty
     TorrentVersion tv = TorrentVersion::V1; // Initialize tv here
     while (true)
     {
-        std::cout << "Torrent version (1-v1, 2-v2, 3-Hybrid) [3]: ";
+        print_info("Torrent version (1-v1, 2-v2, 3-Hybrid) [3]: ");
         std::getline(std::cin, version);
         if (version.empty() || version == "3")
         {
@@ -208,13 +213,13 @@ get_version: // Label to jump to if overwrite is 'n' or empty
         }
         else
         {
-            std::cout << "Error: Invalid input. Please enter '1', '2', or '3'.\n";
+            print_info("Error: Invalid input. Please enter '1', '2', or '3'.\n");
         }
     }
 
     // Get optional comment
     std::string comment;
-    std::cout << "Comment (optional): ";
+    print_info("Comment (optional): ");
     std::getline(std::cin, comment);
 
     // Get private flag
@@ -232,21 +237,21 @@ get_version: // Label to jump to if overwrite is 'n' or empty
         while (true)
         {
             std::string tracker;
-            std::cout << "Add tracker (leave blank to finish): ";
+            print_info("Add tracker (leave blank to finish): ");
             std::getline(std::cin, tracker);
             if (tracker.empty())
                 break;
 
             if (!utils::is_valid_url(tracker))
             {
-                std::cout << "Error: Invalid tracker URL. Must start with http://, https://, "
-                             "or udp://\n";
+                print_info("Error: Invalid tracker URL. Must start with http://, https://, "
+                             "or udp://\n");
                 continue;
             }
 
             if (std::ranges::contains(trackers, tracker))
             {
-                std::cout << "Error: Tracker already added.\n";
+                print_info("Error: Tracker already added.\n");
                 continue;
             }
 
@@ -259,15 +264,14 @@ get_version: // Label to jump to if overwrite is 'n' or empty
     while (true)
     {
         std::string seed;
-        std::cout << "Add web seed (leave blank to finish): ";
+        print_info("Add web seed (leave blank to finish): ");
         std::getline(std::cin, seed);
         if (seed.empty())
             break;
 
         if (!utils::is_valid_url(seed))
         {
-            std::cout
-                << "Error: Invalid web seed URL. Must start with http://, https://, or udp://\n";
+            print_info("Error: Invalid web seed URL. Must start with http://, https://, or udp://\n");
             continue;
         }
 
@@ -281,18 +285,19 @@ get_version: // Label to jump to if overwrite is 'n' or empty
         while (true)
         {
             std::string piece_size_str;
-            std::cout << "Piece size in KB: \n";
+            print_info("Piece size in KB: \n");
 
-            std::cout << "Valid options: ";
+            std::string valid_options = "Valid options: ";
             for (size_t i = 0; i < allowed_piece_sizes.size(); ++i)
             {
-                std::cout << allowed_piece_sizes[i];
+                valid_options += std::to_string(allowed_piece_sizes[i]);
                 if (i < allowed_piece_sizes.size() - 1)
                 {
-                    std::cout << ", ";
+                    valid_options += ", ";
                 }
             }
-            std::cout << "\n";
+            valid_options += "\n";
+            print_info(valid_options);
 
             std::getline(std::cin, piece_size_str);
             if (piece_size_str.empty())
@@ -310,17 +315,17 @@ get_version: // Label to jump to if overwrite is 'n' or empty
                 }
                 else
                 {
-                    std::cout << "Error: Invalid piece size. Please enter a valid option.\n";
+                    print_info("Error: Invalid piece size. Please enter a valid option.\n");
                 }
             }
             catch (const std::invalid_argument &e)
             {
-                std::cout << "Invalid input. Please enter a valid integer.\n";
+                print_info("Invalid input. Please enter a valid integer.\n");
                 continue;
             }
             catch (const std::out_of_range &e)
             {
-                std::cout << "Input out of range. Please enter a valid integer.\n";
+                print_info("Input out of range. Please enter a valid integer.\n");
                 continue;
             }
         }
@@ -341,7 +346,7 @@ get_version: // Label to jump to if overwrite is 'n' or empty
             break;
         }
         if (input_name->find_first_not_of(" \t\n\r") == std::string::npos) {
-            std::cout << "Error: Name cannot be whitespace-only\n";
+            print_info("Error: Name cannot be whitespace-only\n");
             continue;
         }
         torrent_name = input_name;
@@ -365,7 +370,7 @@ get_version: // Label to jump to if overwrite is 'n' or empty
         while (true)
         {
             std::string pattern;
-            std::cout << "Exclude pattern (glob, leave blank to finish): ";
+            print_info("Exclude pattern (glob, leave blank to finish): ");
             std::getline(std::cin, pattern);
             if (pattern.empty())
                 break;
@@ -375,7 +380,7 @@ get_version: // Label to jump to if overwrite is 'n' or empty
             }
             catch (const std::regex_error &)
             {
-                std::cout << "Error: Invalid glob pattern: " << pattern << "\n";
+                print_info(std::string("Error: Invalid glob pattern: ") + pattern + "\n");
                 log_message("Invalid glob pattern entered: " + pattern, LogLevel::WARNING);
             }
         }
@@ -387,7 +392,7 @@ get_version: // Label to jump to if overwrite is 'n' or empty
         while (true)
         {
             std::string pattern;
-            std::cout << "Include pattern (glob, leave blank to finish): ";
+            print_info("Include pattern (glob, leave blank to finish): ");
             std::getline(std::cin, pattern);
             if (pattern.empty())
                 break;
@@ -397,7 +402,7 @@ get_version: // Label to jump to if overwrite is 'n' or empty
             }
             catch (const std::regex_error &)
             {
-                std::cout << "Error: Invalid glob pattern: " << pattern << "\n";
+                print_info(std::string("Error: Invalid glob pattern: ") + pattern + "\n");
                 log_message("Invalid glob pattern entered: " + pattern, LogLevel::WARNING);
             }
         }
@@ -555,16 +560,17 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
         }
         else
         {
-            std::cerr << "Error: Invalid piece size. Must be one of: ";
+            std::string piece_sizes_str = "Error: Invalid piece size. Must be one of: ";
             for (size_t i = 0; i < allowed_piece_sizes.size(); ++i)
             {
-                std::cerr << allowed_piece_sizes[i];
+                piece_sizes_str += std::to_string(allowed_piece_sizes[i]);
                 if (i < allowed_piece_sizes.size() - 1)
                 {
-                    std::cerr << ", ";
+                    piece_sizes_str += ", ";
                 }
             }
-            std::cerr << " KB\n";
+            piece_sizes_str += " KB\n";
+            print_error(piece_sizes_str);
             throw std::runtime_error("Invalid piece size");
         }
     }
@@ -658,12 +664,12 @@ int handle_inspect_command(const std::vector<std::string> &args)
 
         if (result.count("help") || !result.count("path"))
         {
-            std::cout << inspect_options.help() << "\n";
-            std::cout << "\nExamples:\n";
-            std::cout << "  torrent-builder inspect file.torrent\n";
-            std::cout << "  torrent-builder inspect file.torrent --json\n";
-            std::cout << "  torrent-builder inspect file.torrent --files\n";
-            std::cout << "  torrent-builder inspect file.torrent --verify --base-path /data\n";
+            print_info(inspect_options.help() + "\n");
+            print_info("\nExamples:\n");
+            print_info("  torrent-builder inspect file.torrent\n");
+            print_info("  torrent-builder inspect file.torrent --json\n");
+            print_info("  torrent-builder inspect file.torrent --files\n");
+            print_info("  torrent-builder inspect file.torrent --verify --base-path /data\n");
             return 0;
         }
 
@@ -674,7 +680,7 @@ int handle_inspect_command(const std::vector<std::string> &args)
         if (result.count("files"))
         {
             bool json_output = result.count("json") > 0;
-            std::cout << TorrentInspector::format_file_tree(metadata, json_output);
+            print_info(TorrentInspector::format_file_tree(metadata, json_output));
         }
         else if (result.count("verify"))
         {
@@ -682,26 +688,27 @@ int handle_inspect_command(const std::vector<std::string> &args)
             bool verified = inspector.verify_files(base_path);
             if (verified)
             {
-                std::cout << "✓ All files verified successfully\n";
+                print_info("✓ All files verified successfully\n");
                 return 0;
             }
             else
             {
-                std::cerr << "✗ Verification failed - missing or corrupt files\n";
+                print_error("✗ Verification failed - missing or corrupt files\n");
                 return 1;
             }
         }
         else
         {
             bool json_output = result.count("json") > 0;
-            std::cout << TorrentInspector::format_metadata(metadata, json_output);
+            print_info(TorrentInspector::format_metadata(metadata, json_output));
         }
 
         return 0;
     }
     catch (const std::exception &e)
     {
-        std::cerr << "Error: " << e.what() << std::endl;
+        log_message("Inspect error: " + std::string(e.what()), LogLevel::ERR);
+        print_error(std::string("Error: ") + e.what() + "\n");
         return 1;
     }
 }
@@ -724,6 +731,8 @@ int main(int argc, char *argv[])
         // Define command-line options
         cxxopts::Options options("torrent_builder", "Create torrent files");
         options.add_options()("h,help", "Show help")("v,version", "Show version")(
+            "verbose", "Enable verbose output (conflicts with --quiet, --json)")("q,quiet", "Suppress non-essential output, auto-decline prompts (conflicts with --verbose)")(
+            "json", "Output torrent metadata as JSON (implies --quiet, conflicts with --verbose)")(
             "i,interactive", "Run in interactive mode")(
             "t,torrent-version", "Torrent version (1=v1, 2=v2, 3=hybrid)",
             cxxopts::value<std::string>()->default_value("3"),
@@ -756,7 +765,16 @@ int main(int argc, char *argv[])
         options.parse_positional({"path", "output"});
         auto result = options.parse(argc, argv);
 
-        // Help and version
+        if (result.count("verbose") && result.count("quiet")) {
+            print_error("Error: --verbose and --quiet are mutually exclusive\n");
+            return 1;
+        }
+        if (result.count("verbose") && result.count("json")) {
+            print_error("Error: --verbose and --json are mutually exclusive\n");
+            return 1;
+        }
+
+        // Help and version — always print regardless of verbosity
         if (result.count("version"))
         {
             std::cout << "torrent_builder " << TORRENT_BUILDER_VERSION << std::endl;
@@ -787,12 +805,28 @@ int main(int argc, char *argv[])
                          "--exclude \"*.txt\"\n";
             std::cout << "  ./torrent_builder --path /data/folder --include \"*.mkv\" "
                          "--include \"*.mp4\"\n";
+            std::cout << "  ./torrent_builder --path /data/file --verbose\n";
+            std::cout << "  ./torrent_builder --path /data/file --quiet\n";
+            std::cout << "  ./torrent_builder --path /data/file --json\n";
             std::cout << "\nNote: Allowed piece sizes (in KB): 16, 32, 64, 128, 256, 512, 1024, "
                          "2048, 4096, 8192, 16384, 32768\n";
             std::cout << "Glob patterns: * (any non-slash), **/ (zero or more dirs), "
                          "** (any path), ? (single char). Case-insensitive.\n";
             std::cout << "Note: --include patterns take precedence over --exclude when both match.\n";
             return 0;
+        }
+
+        // Set verbosity only when NOT in interactive mode
+        // (interactive mode needs print_info for prompts)
+        if (!result.count("interactive")) {
+            if (result.count("json")) {
+                set_json_mode(true);
+                set_verbosity(Verbosity::QUIET);
+            } else if (result.count("quiet")) {
+                set_verbosity(Verbosity::QUIET);
+            } else if (result.count("verbose")) {
+                set_verbosity(Verbosity::VERBOSE);
+            }
         }
 
         // Run in interactive or command-line mode based on arguments
@@ -808,42 +842,60 @@ int main(int argc, char *argv[])
             auto config_opt = get_commandline_config(result, declined_path);
             if (!config_opt)
             {
-                log_message("User declined to overwrite: " + declined_path, LogLevel::INFO);
-                std::cout << "Operation cancelled.\n";
-                return 0;
+                log_message("Overwrite declined: " + declined_path, LogLevel::INFO);
+                if (is_json_mode()) {
+                    print_error("Error: Output file already exists: " + declined_path + "\n");
+                } else {
+                    print_info("Operation cancelled.\n");
+                }
+                return 1;
             }
             TorrentCreator creator(*config_opt);
             creator.create_torrent();
+            if (is_json_mode()) {
+                try {
+                    TorrentInspector inspector(config_opt->output);
+                    TorrentMetadata meta = inspector.inspect();
+                    std::string json = TorrentInspector::format_metadata(meta, true);
+                    std::string path_field = ",\n  \"output_path\": \"" + utils::escape_json(config_opt->output.string()) + "\"\n";
+                    json.insert(json.rfind('}'), path_field);
+                    std::cout << json;
+                } catch (const std::exception& e) {
+                    log_message("JSON output generation error: " + std::string(e.what()), LogLevel::ERR);
+                    print_error(std::string("Error generating JSON output: ") + e.what() + "\n");
+                    return 1;
+                }
+            }
         }
     }
     catch (const std::filesystem::filesystem_error &e)
     {
         log_message(std::string("Filesystem error: ") + e.what(), LogLevel::ERR);
-        std::cerr << e.what() << std::endl;
+        print_error(std::string(e.what()) + "\n");
         return 1;
     }
     catch (const std::invalid_argument &e)
     {
         log_message(std::string("Invalid argument: ") + e.what(), LogLevel::ERR);
-        std::cerr << e.what() << std::endl;
+        print_error(std::string(e.what()) + "\n");
         return 1;
     }
     catch (const UserInterrupt &e)
     {
         log_message(std::string(e.what()), LogLevel::WARNING);
-        std::cerr << e.what() << std::endl;
+        print_error(std::string(e.what()) + "\n");
         return 1;
     }
     catch (const std::runtime_error &e)
     {
         log_message(std::string("Runtime error: ") + e.what(), LogLevel::ERR);
-        std::cerr << e.what() << std::endl;
+        print_error(std::string(e.what()) + "\n");
         return 1;
     }
     catch (const std::exception &e)
     {
         log_message(std::string("Unexpected error: ") + e.what(), LogLevel::ERR);
-        std::cerr << "An unexpected error occurred: " << e.what() << std::endl;
+        print_error(std::string("An unexpected error occurred: ") + e.what() + "\n");
         return 1;
     }
 

--- a/src/torrent_creator.cpp
+++ b/src/torrent_creator.cpp
@@ -3,6 +3,7 @@
 #include "constants.hpp"
 #include "utils.hpp"
 #include "terminal.hpp"
+#include "output.hpp"
 #include <fstream>
 #include <iomanip>
 #include <chrono>
@@ -342,27 +343,7 @@ void TorrentCreator::hash_large_file(const fs::path& path, lt::create_torrent& t
 
 // Displays a progress bar
 void TorrentCreator::print_progress_bar(int progress, int total, double speed, double eta, int64_t processed, int64_t total_size) const {
-    const int bar_width = 50;
-    float progress_percentage = static_cast<float>(progress) / total;
-    int filled_width = static_cast<int>(std::round(bar_width * progress_percentage));
-
-    std::cout << "[";
-    for (int i = 0; i < bar_width; ++i) {
-        if (i < filled_width) {
-            std::cout << "=";
-        } else {
-            std::cout << " ";
-        }
-    }
-    std::cout << "] " << static_cast<int>(progress_percentage * 100) << "% ";
-
-    // Display processed data / total
-    std::cout << utils::format_size(processed) << " / " << utils::format_size(total_size) << " ";
-
-    std::cout << "Speed: " << utils::format_speed(speed) << " ";
-
-    std::cout << "ETA: " << utils::format_eta(eta) << "\r";
-    std::cout.flush();
+    print_progress(progress, total, speed, eta, processed, total_size);
 }
 
 
@@ -405,9 +386,17 @@ void TorrentCreator::create_torrent() {
 
         // Add files to the file storage
         add_files_to_storage();
+        print_verbose("Files added to storage: " + std::to_string(fs_.num_files()) + " file(s), total size: " + utils::format_size(fs_.total_size()) + "\n");
+        log_message("Files in storage: " + std::to_string(fs_.num_files()) + ", total size: " + std::to_string(fs_.total_size()) + " bytes", LogLevel::INFO);
 
-        // Use the specified piece_size or calculate automatically
         int piece_size = config_.piece_size ? *config_.piece_size : utils::auto_piece_size(fs_.total_size());
+        if (config_.piece_size) {
+            print_verbose("Piece size: " + std::to_string(piece_size / 1024) + " KB (user-specified)\n");
+            log_message("Piece size: " + std::to_string(piece_size / 1024) + " KB (user-specified)", LogLevel::INFO);
+        } else {
+            print_verbose("Piece size: " + std::to_string(piece_size / 1024) + " KB (auto-calculated for " + utils::format_size(fs_.total_size()) + " total)\n");
+            log_message("Piece size: " + std::to_string(piece_size / 1024) + " KB (auto-calculated for " + std::to_string(fs_.total_size()) + " bytes)", LogLevel::INFO);
+        }
         lt::create_flags_t flags = get_torrent_flags(config_.version);
 
         lt::create_torrent t(fs_, piece_size, flags);
@@ -416,10 +405,11 @@ void TorrentCreator::create_torrent() {
         int tier = 0;
         for (const auto& tracker : config_.trackers) {
             t.add_tracker(tracker, tier++);
+            print_verbose("Tracker tier " + std::to_string(tier - 1) + ": " + tracker + "\n");
         }
 
         // Set piece hashes using streaming for large files
-        std::cout << "Hashing pieces...\n";
+        print_info("Hashing pieces...\n");
         log_message("Starting hashing process for: " + config_.path.string(), LogLevel::INFO);
         int num_pieces = t.num_pieces();
 
@@ -556,7 +546,7 @@ void TorrentCreator::create_torrent() {
 
                 if (progress >= num_pieces - 1) {
                     print_progress_bar(num_pieces, num_pieces, speed, 0.0, total_size, total_size);
-                    std::cout << "\n";
+                    print_info("\n");
                     break;
                 }
 
@@ -566,7 +556,7 @@ void TorrentCreator::create_torrent() {
         } else {
             // For single files, hashing is already complete - just show final progress
             print_progress_bar(num_pieces, num_pieces, speed, 0.0, total_size, total_size);
-            std::cout << "\n";
+            print_info("\n");
         }
 
         // If there was an error, throw an exception
@@ -616,15 +606,14 @@ void TorrentCreator::create_torrent() {
         }
 
     } catch (const UserInterrupt&) {
-        std::cerr << "\n";
-        std::cerr.flush();
+        print_error("\n");
         throw;
     } catch (const std::runtime_error& e) {
-        std::cerr << e.what() << std::endl;
+        print_error(std::string(e.what()) + "\n");
         log_message("Runtime error: " + std::string(e.what()), LogLevel::ERR);
         throw;
     } catch (const std::exception& e) {
-        std::cerr << "An unexpected error occurred: " << e.what() << std::endl;
+        print_error(std::string("An unexpected error occurred: ") + e.what() + "\n");
         log_message("Unexpected error: " + std::string(e.what()), LogLevel::ERR);
         throw;
     }
@@ -632,27 +621,26 @@ void TorrentCreator::create_torrent() {
 
 // Prints a summary of the created torrent
 void TorrentCreator::print_torrent_summary(int64_t total_size, int piece_size, int num_pieces) const {
-    std::cout << "\n=== TORRENT CREATED SUCCESSFULLY ===\n";
-    std::cout << "File: " << config_.output << "\n";
+    print_info("\n=== TORRENT CREATED SUCCESSFULLY ===\n");
+    print_info("File: " + config_.output.string() + "\n");
     
-    // Display torrent version
     std::string version_str;
     switch(config_.version) {
         case TorrentVersion::V1: version_str = "v1"; break;
         case TorrentVersion::V2: version_str = "v2"; break;
         case TorrentVersion::HYBRID: version_str = "hybrid"; break;
     }
-    std::cout << "Version: " << version_str << "\n";
+    print_info("Version: " + version_str + "\n");
 
-    std::cout << "Total size: " << utils::format_size(total_size) << "\n";
-    std::cout << "Pieces: " << num_pieces << " of " << piece_size / 1024 << "KB\n"; // Show piece_size in KB
-    std::cout << "Trackers: " << config_.trackers.size() << "\n"; // Simplified tracker count
-    std::cout << "Web seeds: " << config_.web_seeds.size() << "\n";
-    std::cout << "Private: " << (config_.is_private ? "Yes" : "No") << "\n";
+    print_info("Total size: " + utils::format_size(total_size) + "\n");
+    print_info("Pieces: " + std::to_string(num_pieces) + " of " + std::to_string(piece_size / 1024) + "KB\n");
+    print_info("Trackers: " + std::to_string(config_.trackers.size()) + "\n");
+    print_info("Web seeds: " + std::to_string(config_.web_seeds.size()) + "\n");
+    print_info("Private: " + std::string(config_.is_private ? "Yes" : "No") + "\n");
     if (config_.source) {
-        std::cout << "Source: " << *config_.source << "\n";
+        print_info("Source: " + *config_.source + "\n");
     }
     if (config_.entropy) {
-        std::cout << "Entropy: Yes (randomized info hash)\n";
+        print_info("Entropy: Yes (randomized info hash)\n");
     }
 }

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -2022,11 +2022,13 @@ TEST(CLI, QuietOverwriteAutoDeclines) {
         + " --output " + output_file + " --quiet 2>&1", exit_code);
 
     EXPECT_EQ(exit_code, 1) << "Quiet mode should auto-decline overwrite with exit code 1";
-    std::ifstream check(output_file);
-    std::string content((std::istreambuf_iterator<char>(check)),
-                        std::istreambuf_iterator<char>());
-    EXPECT_EQ(content, "dummy torrent content")
-        << "Original file should be preserved when quiet auto-declines overwrite";
+    {
+        std::ifstream check(output_file);
+        std::string content((std::istreambuf_iterator<char>(check)),
+                            std::istreambuf_iterator<char>());
+        EXPECT_EQ(content, "dummy torrent content")
+            << "Original file should be preserved when quiet auto-declines overwrite";
+    }
 
     fs::remove_all(temp_dir);
 }
@@ -2066,11 +2068,13 @@ TEST(CLI, JsonOverwriteAutoDeclines) {
         + " --output " + output_file + " --json 2>&1", exit_code);
 
     EXPECT_EQ(exit_code, 1) << "JSON mode should auto-decline overwrite. Output: " << output;
-    std::ifstream check(output_file);
-    std::string content((std::istreambuf_iterator<char>(check)),
-                        std::istreambuf_iterator<char>());
-    EXPECT_EQ(content, "dummy torrent content")
-        << "Original file should be preserved when JSON auto-declines overwrite";
+    {
+        std::ifstream check(output_file);
+        std::string content((std::istreambuf_iterator<char>(check)),
+                            std::istreambuf_iterator<char>());
+        EXPECT_EQ(content, "dummy torrent content")
+            << "Original file should be preserved when JSON auto-declines overwrite";
+    }
 
     fs::remove_all(temp_dir);
 }

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -197,7 +197,7 @@ TEST(CLI, OverwriteDeclinedExitsZero) {
     int exit_code;
     std::string output = exec_command(cmd, exit_code);
 
-    EXPECT_EQ(exit_code, 0);
+    EXPECT_EQ(exit_code, 1);
     EXPECT_NE(output.find("Operation cancelled"), std::string::npos) << "Output: " << output;
 
     // Verify the original file was NOT overwritten
@@ -271,11 +271,11 @@ TEST(CLI, OverwriteDeclinedLogsToFile) {
     int exit_code;
     std::string output = exec_command(cmd, exit_code);
 
-    EXPECT_EQ(exit_code, 0);
+    EXPECT_EQ(exit_code, 1);
 
     std::string log = read_log_file(temp_dir);
     EXPECT_NE(log.find("[INFO]"), std::string::npos) << "Log: " << log;
-    EXPECT_NE(log.find("User declined to overwrite"), std::string::npos) << "Log: " << log;
+    EXPECT_NE(log.find("Overwrite declined"), std::string::npos) << "Log: " << log;
 
     fs::remove_all(temp_dir, ec);
 }
@@ -361,7 +361,7 @@ TEST(CLI, OverwriteDeclinedPreservesFileContent) {
     int exit_code;
     std::string output = exec_command(cmd, exit_code);
 
-    EXPECT_EQ(exit_code, 0);
+    EXPECT_EQ(exit_code, 1);
 
     // Verify file content is unchanged
     std::ifstream check(output_file);
@@ -372,7 +372,7 @@ TEST(CLI, OverwriteDeclinedPreservesFileContent) {
 
     // Verify log entry includes the output path
     std::string log = read_log_file(temp_dir);
-    EXPECT_NE(log.find("User declined to overwrite"), std::string::npos) << "Log: " << log;
+    EXPECT_NE(log.find("Overwrite declined"), std::string::npos) << "Log: " << log;
     EXPECT_NE(log.find(output_file.filename().string()), std::string::npos) << "Log: " << log;
 
     fs::remove_all(temp_dir, ec);
@@ -656,7 +656,7 @@ TEST(CLI, ExplicitOutputStillPromptsOverwrite) {
     int exit_code;
     std::string output = exec_command(cmd, exit_code);
 
-    EXPECT_EQ(exit_code, 0);
+    EXPECT_EQ(exit_code, 1);
     EXPECT_NE(output.find("Operation cancelled"), std::string::npos)
         << "Explicit --output should still prompt overwrite. Output: " << output;
 
@@ -1898,4 +1898,231 @@ TEST(CLI, IncludePatternNestedDirectories) {
     EXPECT_FALSE(has_txt) << "readme.txt should be excluded";
 
     fs::remove_all(temp_dir);
+}
+
+TEST(CLI, VerboseQuietMutualExclusion) {
+    int exit_code;
+    std::string output = exec_command(get_binary_path() + " --verbose --quiet 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 1);
+    EXPECT_NE(output.find("mutually exclusive"), std::string::npos);
+}
+
+TEST(CLI, VerboseJsonMutualExclusion) {
+    int exit_code;
+    std::string output = exec_command(get_binary_path() + " --verbose --json 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 1);
+    EXPECT_NE(output.find("mutually exclusive"), std::string::npos);
+}
+
+TEST(CLI, HelpShowsVerbose) {
+    int exit_code;
+    std::string output = exec_command(get_binary_path() + " --help", exit_code);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_NE(output.find("--verbose"), std::string::npos);
+}
+
+TEST(CLI, HelpShowsQuiet) {
+    int exit_code;
+    std::string output = exec_command(get_binary_path() + " --help", exit_code);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_NE(output.find("--quiet"), std::string::npos);
+}
+
+TEST(CLI, HelpShowsJson) {
+    int exit_code;
+    std::string output = exec_command(get_binary_path() + " --help", exit_code);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_NE(output.find("--json"), std::string::npos);
+}
+
+TEST(CLI, QuietModeSuppressesOutput) {
+    auto temp_dir = fs::temp_directory_path() / "tb_quiet_test";
+    fs::create_directories(temp_dir);
+    std::ofstream(temp_dir / "file.bin") << "quiet test data";
+
+    std::string output_file = (temp_dir / "quiet.torrent").string();
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " --path " + (temp_dir / "file.bin").string()
+        + " --output " + output_file + " --quiet 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_TRUE(output.empty() || output.find("TORRENT CREATED") == std::string::npos)
+        << "Quiet mode should suppress creation summary. Output: " << output;
+
+    ASSERT_TRUE(fs::exists(output_file));
+    fs::remove_all(temp_dir);
+}
+
+TEST(CLI, JsonModeOutputIsValidJson) {
+    auto temp_dir = fs::temp_directory_path() / "tb_json_test";
+    fs::create_directories(temp_dir);
+    std::ofstream(temp_dir / "file.bin") << "json test data here";
+
+    std::string output_file = (temp_dir / "json_out.torrent").string();
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " --path " + (temp_dir / "file.bin").string()
+        + " --output " + output_file + " --json 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    ASSERT_TRUE(fs::exists(output_file));
+
+    EXPECT_NE(output.find("\"name\""), std::string::npos) << "JSON should contain 'name' field";
+    EXPECT_NE(output.find("\"info_hash_v1\""), std::string::npos) << "JSON should contain info_hash_v1";
+    EXPECT_NE(output.find("\"total_size\""), std::string::npos) << "JSON should contain total_size";
+    EXPECT_NE(output.find("\"piece_length\""), std::string::npos) << "JSON should contain piece_length";
+    EXPECT_NE(output.find("\"piece_count\""), std::string::npos) << "JSON should contain piece_count";
+    EXPECT_NE(output.find("\"is_private\""), std::string::npos) << "JSON should contain is_private";
+    EXPECT_NE(output.find("\"trackers\""), std::string::npos) << "JSON should contain trackers";
+    EXPECT_NE(output.find("\"output_path\""), std::string::npos) << "JSON should contain output_path";
+    EXPECT_NE(output.find("json_out.torrent"), std::string::npos) << "JSON output_path should contain the torrent filename";
+
+    ASSERT_GT(output.size(), 1u);
+    EXPECT_EQ(output.front(), '{') << "JSON output should start with '{'";
+    std::string trimmed = output;
+    while (!trimmed.empty() && (trimmed.back() == '\n' || trimmed.back() == '\r'))
+        trimmed.pop_back();
+    EXPECT_EQ(trimmed.back(), '}') << "JSON output should end with '}'";
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(CLI, JsonWithTrackers) {
+    auto temp_dir = fs::temp_directory_path() / "tb_json_trackers";
+    fs::create_directories(temp_dir);
+    std::ofstream(temp_dir / "file.bin") << "json tracker test";
+
+    std::string output_file = (temp_dir / "json_track.torrent").string();
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " --path " + (temp_dir / "file.bin").string()
+        + " --output " + output_file
+        + " --tracker \"https://tracker.example/announce\""
+        + " --json 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_NE(output.find("tracker.example"), std::string::npos)
+        << "JSON output should contain tracker URL";
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(CLI, QuietOverwriteAutoDeclines) {
+    auto temp_dir = fs::temp_directory_path() / "tb_quiet_overwrite";
+    fs::create_directories(temp_dir);
+    std::ofstream(temp_dir / "file.bin") << "overwrite test";
+
+    std::string output_file = (temp_dir / "existing.torrent").string();
+    std::ofstream(output_file) << "dummy torrent content";
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " --path " + (temp_dir / "file.bin").string()
+        + " --output " + output_file + " --quiet 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 1) << "Quiet mode should auto-decline overwrite with exit code 1";
+    std::ifstream check(output_file);
+    std::string content((std::istreambuf_iterator<char>(check)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "dummy torrent content")
+        << "Original file should be preserved when quiet auto-declines overwrite";
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(CLI, VerboseShowsPieceSizeInfo) {
+    auto temp_dir = fs::temp_directory_path() / "tb_verbose_test";
+    fs::create_directories(temp_dir);
+    std::ofstream(temp_dir / "file.bin") << "verbose test data";
+
+    std::string output_file = (temp_dir / "verbose.torrent").string();
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " --path " + (temp_dir / "file.bin").string()
+        + " --output " + output_file + " --verbose 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_NE(output.find("Piece size:"), std::string::npos)
+        << "Verbose should show piece size info";
+    EXPECT_NE(output.find("Files added to storage:"), std::string::npos)
+        << "Verbose should show file count";
+
+    ASSERT_TRUE(fs::exists(output_file));
+    fs::remove_all(temp_dir);
+}
+
+TEST(CLI, JsonOverwriteAutoDeclines) {
+    auto temp_dir = fs::temp_directory_path() / "tb_json_overwrite";
+    fs::create_directories(temp_dir);
+    std::ofstream(temp_dir / "file.bin") << "overwrite json test";
+
+    std::string output_file = (temp_dir / "existing.torrent").string();
+    std::ofstream(output_file) << "dummy torrent content";
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " --path " + (temp_dir / "file.bin").string()
+        + " --output " + output_file + " --json 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 1) << "JSON mode should auto-decline overwrite. Output: " << output;
+    std::ifstream check(output_file);
+    std::string content((std::istreambuf_iterator<char>(check)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "dummy torrent content")
+        << "Original file should be preserved when JSON auto-declines overwrite";
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(CLI, NormalModeNoVerboseMessages) {
+    auto temp_dir = fs::temp_directory_path() / "tb_normal_test";
+    fs::create_directories(temp_dir);
+    std::ofstream(temp_dir / "file.bin") << "normal mode test";
+
+    std::string output_file = (temp_dir / "normal.torrent").string();
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " --path " + (temp_dir / "file.bin").string()
+        + " --output " + output_file + " 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_EQ(output.find("Files added to storage:"), std::string::npos)
+        << "Normal mode should not show verbose file count";
+    EXPECT_EQ(output.find("Piece size:"), std::string::npos)
+        << "Normal mode should not show verbose piece size info";
+
+    ASSERT_TRUE(fs::exists(output_file));
+    fs::remove_all(temp_dir);
+}
+
+TEST(CLI, JsonQuietComboWorks) {
+    auto temp_dir = fs::temp_directory_path() / "tb_json_quiet";
+    fs::create_directories(temp_dir);
+    std::ofstream(temp_dir / "file.bin") << "json+quiet test";
+
+    std::string output_file = (temp_dir / "jq.torrent").string();
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " --path " + (temp_dir / "file.bin").string()
+        + " --output " + output_file + " --json --quiet 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_NE(output.find("\"name\""), std::string::npos) << "JSON output expected";
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(CLI, HelpAlwaysVisibleEvenWithQuiet) {
+    int exit_code;
+    std::string output = exec_command(get_binary_path() + " --help --quiet 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_NE(output.find("--verbose"), std::string::npos) << "--help should show output even with --quiet";
+}
+
+TEST(CLI, VersionAlwaysVisibleEvenWithQuiet) {
+    int exit_code;
+    std::string output = exec_command(get_binary_path() + " --version --quiet 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_NE(output.find("torrent_builder"), std::string::npos) << "--version should show output even with --quiet";
 }


### PR DESCRIPTION
## Summary

Add `--verbose`, `--quiet` (`-q`), and `--json` CLI flags to the torrent builder, introducing a centralized output abstraction that controls console output by verbosity level, supports machine-readable JSON output, and auto-declines overwrite prompts in quiet/JSON modes for script-friendly behavior.

## Motivation

The tool previously used raw `std::cout`/`std::cerr` scattered across the codebase, making it impossible to suppress progress bars in CI pipelines, get structured data for scripting, or enable extra diagnostics for debugging.

## Changes Made

- New output abstraction (`include/output.hpp`, `src/output.cpp`) with `Verbosity` enum and four print functions gated by verbosity/JSON mode
- Three new CLI flags with mutual exclusion validation (`--verbose` conflicts with `--quiet` and `--json`)
- All `std::cout`/`std::cerr` replaced with `print_info`, `print_verbose`, `print_error`, `print_progress`
- Verbose diagnostics: file count, piece size reasoning, tracker tier assignments
- JSON output with `output_path` field via `TorrentInspector::format_metadata()`; errors go to stderr
- Auto-decline overwrite prompts in quiet/JSON modes with exit code 1
- 15 new CLI tests; README updated with flags, JSON format docs, and examples

## Testing

- [x] Tested locally
- [x] Unit tests added/updated
- [x] Documentation updated

## Breaking Changes

- **Overwrite-declined exit code** changed from 0 to 1. Scripts relying on exit code 0 for success may need updating.
- **Log message** changed from `"User declined to overwrite"` to `"Overwrite declined"`. Log-parsing scripts may need updating.

## Related Issues

Closes #24