### PR TITLE
feat(modify): add torrent metadata modification subcommand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ FetchContent_MakeAvailable(googletest)
 add_library(torrent_builder_core STATIC
     src/torrent_creator.cpp
     src/torrent_inspector.cpp
+    src/torrent_modifier.cpp
     src/logger.cpp
     src/utils.cpp
     src/terminal.cpp

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The **Torrent Builder** is a command-line tool for creating torrent files, offer
 
 - Create torrent files from single files or directories
 - Inspect existing torrent files (metadata, file tree, verification, magnet link)
+- Modify existing torrent metadata without re-hashing file content
 - Support for torrent versions: V1, V2, and Hybrid
 - Interactive mode with step-by-step configuration
 - Command-line interface with options for all features
@@ -87,6 +88,14 @@ For an optimized Release build: `cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --
 ./torrent_builder inspect file.torrent [options]
 ```
 
+### Modify Torrent Metadata
+
+```bash
+./torrent_builder modify file.torrent [options]
+```
+
+Edit metadata of an existing .torrent file in-place without re-hashing file content. Supports V1, V2, and hybrid torrents. Changes are written atomically (temp file + rename).
+
 > **Note:** `--output` is optional. When omitted, the output filename is auto-generated from the tracker domain and content name (e.g., `tracker.example.com_myfile.torrent`).
 
 ## Options
@@ -157,6 +166,27 @@ Optional fields (`comment`, `creation_date`, `created_by`, `source`, `entropy`) 
   --verify         Verify files exist on disk
   --base-path DIR  Base path for file verification (default: current directory)
 ```
+
+### Modify Options
+
+```
+  ./torrent_builder modify <torrent_file> [options]
+
+  -h, --help              Show help
+  -t, --tracker URL       Replace all trackers (exclusive with --add-tracker/--remove-tracker)
+      --add-tracker URL   Add tracker URL (can be used multiple times)
+      --remove-tracker URL Remove tracker URL (can be used multiple times)
+      --private           Mark torrent as private
+      --public            Mark torrent as public
+      --source SOURCE     Set source field (empty string removes it)
+      --comment COMMENT   Set comment (empty string removes it)
+      --name NAME         Change torrent name
+      --entropy           Randomize info hash by adding entropy field
+  -o, --output OUTPUT     Output torrent file path (defaults to in-place)
+      --dry-run           Preview changes without writing
+```
+
+> **Note:** `--tracker` is exclusive with `--add-tracker`/`--remove-tracker`. `--private` and `--public` are mutually exclusive. At least one modification option is required.
 
 ## Examples
 
@@ -280,6 +310,45 @@ Inspect torrent metadata:
 
 ./torrent_builder inspect file.torrent --verify --base-path /data
 # Verifies all files exist on disk under /data
+```
+
+Modify torrent metadata:
+```bash
+./torrent_builder modify file.torrent --tracker "https://tracker.example/announce"
+# Replaces all trackers with the specified one
+
+./torrent_builder modify file.torrent --add-tracker "https://tracker2.example/announce"
+# Adds a tracker to the existing list
+
+./torrent_builder modify file.torrent --remove-tracker "https://old.example/announce"
+# Removes a specific tracker
+
+./torrent_builder modify file.torrent --private
+# Marks torrent as private
+
+./torrent_builder modify file.torrent --public
+# Marks torrent as public (removes private flag)
+
+./torrent_builder modify file.torrent --source "PTP"
+# Sets source field for cross-seeding
+
+./torrent_builder modify file.torrent --source ""
+# Removes source field
+
+./torrent_builder modify file.torrent --comment "Updated comment"
+# Sets or updates comment
+
+./torrent_builder modify file.torrent --comment ""
+# Removes comment
+
+./torrent_builder modify file.torrent --name "New Name" --entropy
+# Changes torrent name and randomizes info hash
+
+./torrent_builder modify file.torrent --dry-run --tracker "https://tracker.example/announce"
+# Preview changes without writing to file
+
+./torrent_builder modify file.torrent --output modified.torrent --entropy
+# Write to a new file instead of modifying in-place
 ```
 
 ## Troubleshooting

--- a/include/torrent_modifier.hpp
+++ b/include/torrent_modifier.hpp
@@ -1,0 +1,72 @@
+#ifndef TORRENT_MODIFIER_HPP
+#define TORRENT_MODIFIER_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <filesystem>
+#include <libtorrent/entry.hpp>
+
+namespace fs = std::filesystem;
+
+namespace lt = libtorrent;
+
+/**
+ * @brief Configuration for torrent metadata modification operations.
+ */
+struct ModifyConfig
+{
+    fs::path input;
+    fs::path output;                                           // Empty = in-place modification
+    std::optional<std::vector<std::string>> trackers;          // nullopt=unchanged, empty=clear all
+    std::vector<std::string> add_trackers;
+    std::vector<std::string> remove_trackers;
+    std::optional<bool> is_private;                            // true=private, false=public, nullopt=unchanged
+    std::optional<std::string> source;                         // Empty string removes the field
+    std::optional<std::string> comment;                        // Empty string removes the field
+    std::optional<std::string> name;
+    bool entropy = false;                                      // Randomize info hash via entropy field
+    bool dry_run = false;                                      // Preview changes without writing
+};
+
+/**
+ * @brief Modify torrent metadata without re-hashing file content.
+ *
+ * Reads an existing .torrent file, applies metadata-only modifications
+ * (trackers, private flag, source, comment, name, entropy), and writes
+ * the result. Supports dry-run mode and atomic in-place writes.
+ */
+class TorrentModifier
+{
+  public:
+    /**
+     * @brief Construct a modifier with the given configuration.
+     * @param config Modification parameters (input file, options, output).
+     */
+    explicit TorrentModifier(const ModifyConfig &config);
+
+    /**
+     * @brief Load, apply modifications, print hash diff, and save.
+     * @throws std::runtime_error on I/O or parse failures.
+     */
+    void modify();
+
+  private:
+    ModifyConfig config_;
+    std::vector<char> raw_buffer_;
+    std::string old_hash_v1_;
+    std::string old_hash_v2_;
+
+    void load();
+    void apply_modifications(lt::entry &root);
+    void save(const std::vector<char> &buffer);
+    std::pair<std::string, std::string> compute_hashes(const std::vector<char> &buffer) const;
+    void rebuild_trackers(lt::entry &root, const std::vector<std::string> &urls);
+    void add_trackers(lt::entry &root, const std::vector<std::string> &urls);
+    void remove_trackers(lt::entry &root, const std::vector<std::string> &urls);
+    std::vector<std::string> remove_url_from_tiers(lt::entry::list_type &tiers, const std::vector<std::string> &urls);
+    void update_announce_from_remaining(lt::entry &root, const std::vector<std::string> &remaining);
+    void print_diff(const std::string &new_hash_v1, const std::string &new_hash_v2) const;
+};
+
+#endif // TORRENT_MODIFIER_HPP

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -241,8 +241,38 @@ std::regex glob_to_regex(const std::string &pattern);
  * @return true if the file should be included in the torrent, false to exclude it.
  */
 bool should_include_file(const std::string &relative_path,
-                          const std::vector<std::regex> &exclude_regex,
-                          const std::vector<std::regex> &include_regex);
+                           const std::vector<std::regex> &exclude_regex,
+                           const std::vector<std::regex> &include_regex);
+
+/**
+ * @brief Generate 32 random bytes as a 64-char lowercase hex string.
+ * @return 64-character hex string suitable for use as torrent info entropy field.
+ */
+std::string generate_entropy_hex();
+
+/**
+ * @brief Write data directly to a file via std::ofstream.
+ *
+ * Used as fallback by atomic_write when rename fails across devices.
+ *
+ * @param dest Output file path.
+ * @param data Binary content to write.
+ * @throws std::runtime_error on I/O failure.
+ */
+void direct_write(const std::filesystem::path &dest, const std::vector<char> &data);
+
+/**
+ * @brief Atomically write data to a file via temp file + rename.
+ *
+ * Writes to a temporary file first, then renames to the destination.
+ * Falls back to direct_write on cross-device link errors.
+ * Cleans up the temporary file in all error paths.
+ *
+ * @param dest Output file path.
+ * @param data Binary content to write.
+ * @throws std::runtime_error on I/O failure.
+ */
+void atomic_write(const std::filesystem::path &dest, const std::vector<char> &data);
 
 } // namespace utils
 

--- a/src/torrent_builder.cpp
+++ b/src/torrent_builder.cpp
@@ -13,6 +13,7 @@
 #include <ranges>
 #include <stdexcept>
 #include "torrent_inspector.hpp"
+#include "torrent_modifier.hpp"
 #include "output.hpp"
 
 namespace fs = std::filesystem;
@@ -713,9 +714,180 @@ int handle_inspect_command(const std::vector<std::string> &args)
     }
 }
 
+int handle_modify_command(const std::vector<std::string> &args)
+{
+    try
+    {
+        int argc = static_cast<int>(args.size()) + 1;
+        std::vector<const char *> argv;
+        argv.push_back("torrent-builder");
+        for (const auto &arg : args)
+        {
+            argv.push_back(arg.c_str());
+        }
+
+        cxxopts::Options modify_options("torrent-builder modify", "Modify torrent metadata");
+        modify_options.add_options()(
+            "h,help", "Show help")(
+            "t,tracker", "Replace all trackers (exclusive with --add-tracker/--remove-tracker)",
+            cxxopts::value<std::vector<std::string>>(), "URL")(
+            "add-tracker", "Add tracker URL",
+            cxxopts::value<std::vector<std::string>>(), "URL")(
+            "remove-tracker", "Remove tracker URL",
+            cxxopts::value<std::vector<std::string>>(), "URL")(
+            "private", "Mark torrent as private")(
+            "public", "Mark torrent as public")(
+            "source", "Set source field (empty string removes it)",
+            cxxopts::value<std::string>(), "SOURCE")(
+            "comment", "Set comment (empty string removes it)",
+            cxxopts::value<std::string>(), "COMMENT")(
+            "name", "Change torrent name",
+            cxxopts::value<std::string>(), "NAME")(
+            "entropy", "Randomize info hash by adding entropy field")(
+            "o,output", "Output torrent file path (defaults to in-place)",
+            cxxopts::value<std::string>(), "OUTPUT")(
+            "dry-run", "Preview changes without writing")(
+            "input", "Input torrent file",
+            cxxopts::value<std::string>());
+
+        modify_options.parse_positional({"input"});
+        auto result = modify_options.parse(argc, argv.data());
+
+        if (result.count("help") || !result.count("input"))
+        {
+            print_info(modify_options.help() + "\n");
+            print_info("\nExamples:\n");
+            print_info("  torrent-builder modify file.torrent --tracker \"https://tracker.example/announce\"\n");
+            print_info("  torrent-builder modify file.torrent --add-tracker \"https://tracker2.example/announce\"\n");
+            print_info("  torrent-builder modify file.torrent --remove-tracker \"https://old.example/announce\"\n");
+            print_info("  torrent-builder modify file.torrent --private\n");
+            print_info("  torrent-builder modify file.torrent --public\n");
+            print_info("  torrent-builder modify file.torrent --source \"PTP\"\n");
+            print_info("  torrent-builder modify file.torrent --source \"\" --comment \"Updated\"\n");
+            print_info("  torrent-builder modify file.torrent --name \"New Name\" --entropy\n");
+            print_info("  torrent-builder modify file.torrent --dry-run --tracker \"https://tracker.example/announce\"\n");
+            print_info("  torrent-builder modify file.torrent --output modified.torrent --entropy\n");
+            return 0;
+        }
+
+        if (result.count("tracker") && (result.count("add-tracker") || result.count("remove-tracker")))
+        {
+            print_error("Error: --tracker is exclusive with --add-tracker/--remove-tracker\n");
+            return 1;
+        }
+
+        if (result.count("private") && result.count("public"))
+        {
+            print_error("Error: --private and --public are mutually exclusive\n");
+            return 1;
+        }
+
+        bool has_modification = result.count("tracker") || result.count("add-tracker") ||
+                                result.count("remove-tracker") || result.count("private") ||
+                                result.count("public") || result.count("source") ||
+                                result.count("comment") || result.count("name") ||
+                                result.count("entropy");
+
+        if (!has_modification && !result.count("dry-run"))
+        {
+            print_error("Error: at least one modification option is required\n");
+            return 1;
+        }
+
+        ModifyConfig config;
+        config.input = result["input"].as<std::string>();
+
+        if (result.count("output"))
+        {
+            config.output = result["output"].as<std::string>();
+        }
+
+        if (result.count("tracker"))
+        {
+            auto urls = result["tracker"].as<std::vector<std::string>>();
+            for (const auto &url : urls)
+            {
+                if (!utils::is_valid_url(url))
+                    throw std::runtime_error("Invalid tracker URL: " + url);
+            }
+            config.trackers = std::move(urls);
+        }
+
+        if (result.count("add-tracker"))
+        {
+            auto urls = result["add-tracker"].as<std::vector<std::string>>();
+            for (const auto &url : urls)
+            {
+                if (!utils::is_valid_url(url))
+                    throw std::runtime_error("Invalid tracker URL: " + url);
+            }
+            config.add_trackers = std::move(urls);
+        }
+
+        if (result.count("remove-tracker"))
+        {
+            auto urls = result["remove-tracker"].as<std::vector<std::string>>();
+            for (const auto &url : urls)
+            {
+                if (!utils::is_valid_url(url))
+                    throw std::runtime_error("Invalid tracker URL: " + url);
+            }
+            config.remove_trackers = std::move(urls);
+        }
+
+        if (result.count("private"))
+        {
+            config.is_private = true;
+        }
+        else if (result.count("public"))
+        {
+            config.is_private = false;
+        }
+
+        if (result.count("source"))
+        {
+            config.source = result["source"].as<std::string>();
+        }
+
+        if (result.count("comment"))
+        {
+            config.comment = result["comment"].as<std::string>();
+        }
+
+        if (result.count("name"))
+        {
+            config.name = result["name"].as<std::string>();
+        }
+
+        config.entropy = result.count("entropy") > 0;
+        config.dry_run = result.count("dry-run") > 0;
+
+        TorrentModifier modifier(config);
+        modifier.modify();
+
+        return 0;
+    }
+    catch (const std::exception &e)
+    {
+        log_message("Modify error: " + std::string(e.what()), LogLevel::ERR);
+        print_error(std::string("Error: ") + e.what() + "\n");
+        return 1;
+    }
+}
+
 int main(int argc, char *argv[])
 {
     // Check for subcommands
+    if (argc >= 2 && std::string(argv[1]) == "modify")
+    {
+        std::vector<std::string> args;
+        for (int i = 2; i < argc; ++i)
+        {
+            args.push_back(argv[i]);
+        }
+        return handle_modify_command(args);
+    }
+
     if (argc >= 2 && std::string(argv[1]) == "inspect")
     {
         std::vector<std::string> args;

--- a/src/torrent_creator.cpp
+++ b/src/torrent_creator.cpp
@@ -14,29 +14,6 @@
 #include <thread>
 #include <stdexcept>
 #include <system_error>
-#include <random>
-
-namespace {
-constexpr char HEX_CHARS[] = "0123456789abcdef";
-
-// Generates 32 random bytes (256 bits) as a 64-char hex string.
-// Hex encoding ensures the bencode string field stays valid UTF-8.
-std::string generate_entropy_hex()
-{
-    std::random_device rd;
-    // Note: rd.entropy() may return 0 on some platforms (MSVC, MinGW) even when
-    // the implementation uses a proper entropy source. We avoid blocking on that
-    // check and let the call succeed or throw naturally from the OS.
-    std::uniform_int_distribution<unsigned> dist(0, 255);
-    std::string result(64, '\0');
-    for (int i = 0; i < 32; ++i) {
-        unsigned byte = dist(rd);
-        result[i * 2] = HEX_CHARS[byte >> 4];
-        result[i * 2 + 1] = HEX_CHARS[byte & 0xF];
-    }
-    return result;
-}
-}
 
 // Constructor for TorrentCreator
 TorrentCreator::TorrentCreator(const TorrentConfig& config)
@@ -584,7 +561,7 @@ void TorrentCreator::create_torrent() {
 
             if (config_.entropy) {
                 try {
-                    e["info"]["entropy"] = generate_entropy_hex();
+                    e["info"]["entropy"] = utils::generate_entropy_hex();
                 } catch (const std::exception& ex) {
                     log_message("Failed to generate entropy: " + std::string(ex.what()), LogLevel::ERR);
                     throw std::runtime_error("Failed to generate entropy: " + std::string(ex.what()));

--- a/src/torrent_modifier.cpp
+++ b/src/torrent_modifier.cpp
@@ -1,0 +1,411 @@
+#include "torrent_modifier.hpp"
+#include "torrent_inspector.hpp"
+#include "logger.hpp"
+#include "utils.hpp"
+#include "output.hpp"
+#include <libtorrent/torrent_info.hpp>
+#include <libtorrent/bencode.hpp>
+#include <libtorrent/entry.hpp>
+#include <libtorrent/info_hash.hpp>
+#include <fstream>
+#include <algorithm>
+#include <iomanip>
+
+TorrentModifier::TorrentModifier(const ModifyConfig &config) : config_(config)
+{
+}
+
+void TorrentModifier::modify()
+{
+    load();
+
+    lt::entry root = lt::bdecode(lt::span<const char>(raw_buffer_.data(), raw_buffer_.size()));
+
+    apply_modifications(root);
+
+    std::vector<char> new_buffer;
+    lt::bencode(std::back_inserter(new_buffer), root);
+
+    auto [new_hash_v1, new_hash_v2] = compute_hashes(new_buffer);
+    print_diff(new_hash_v1, new_hash_v2);
+
+    if (!config_.dry_run)
+    {
+        save(new_buffer);
+    }
+}
+
+void TorrentModifier::load()
+{
+    if (!fs::exists(config_.input))
+    {
+        throw std::runtime_error("Torrent file does not exist: " + config_.input.string());
+    }
+
+    std::ifstream file(config_.input, std::ios::binary);
+    if (!file)
+    {
+        throw std::runtime_error("Failed to open torrent file: " + config_.input.string());
+    }
+
+    raw_buffer_ = std::vector<char>((std::istreambuf_iterator<char>(file)),
+                                     std::istreambuf_iterator<char>());
+
+    if (raw_buffer_.empty())
+    {
+        throw std::runtime_error("Torrent file is empty: " + config_.input.string());
+    }
+
+    auto [h1, h2] = compute_hashes(raw_buffer_);
+    old_hash_v1_ = h1;
+    old_hash_v2_ = h2;
+}
+
+void TorrentModifier::apply_modifications(lt::entry &root)
+{
+    lt::entry *info = root.find_key("info");
+    if (info == nullptr)
+    {
+        throw std::runtime_error("Invalid torrent: missing 'info' dictionary");
+    }
+
+    if (config_.trackers.has_value())
+    {
+        rebuild_trackers(root, *config_.trackers);
+        log_message("Modify: replaced trackers (" + std::to_string(config_.trackers->size()) + " URLs)", LogLevel::INFO);
+    }
+    else if (!config_.add_trackers.empty() || !config_.remove_trackers.empty())
+    {
+        remove_trackers(root, config_.remove_trackers);
+        add_trackers(root, config_.add_trackers);
+        if (!config_.remove_trackers.empty())
+            log_message("Modify: removed " + std::to_string(config_.remove_trackers.size()) + " tracker(s)", LogLevel::INFO);
+        if (!config_.add_trackers.empty())
+            log_message("Modify: added " + std::to_string(config_.add_trackers.size()) + " tracker(s)", LogLevel::INFO);
+    }
+
+    if (config_.is_private.has_value())
+    {
+        (*info)["private"] = lt::entry(*config_.is_private ? 1 : 0);
+        log_message("Modify: set private=" + std::string(*config_.is_private ? "true" : "false"), LogLevel::INFO);
+    }
+
+    if (config_.source.has_value())
+    {
+        if (config_.source->empty())
+        {
+            lt::entry::dictionary_type &dict = info->dict();
+            dict.erase("source");
+            log_message("Modify: removed source field", LogLevel::INFO);
+        }
+        else
+        {
+            (*info)["source"] = lt::entry(*config_.source);
+            log_message("Modify: set source=\"" + *config_.source + "\"", LogLevel::INFO);
+        }
+    }
+
+    if (config_.comment.has_value())
+    {
+        if (config_.comment->empty())
+        {
+            lt::entry::dictionary_type &dict = root.dict();
+            dict.erase("comment");
+            log_message("Modify: removed comment field", LogLevel::INFO);
+        }
+        else
+        {
+            root["comment"] = lt::entry(*config_.comment);
+            log_message("Modify: set comment=\"" + *config_.comment + "\"", LogLevel::INFO);
+        }
+    }
+
+    if (config_.name.has_value())
+    {
+        (*info)["name"] = lt::entry(*config_.name);
+        log_message("Modify: set name=\"" + *config_.name + "\"", LogLevel::INFO);
+    }
+
+    if (config_.entropy)
+    {
+        try
+        {
+            (*info)["entropy"] = lt::entry(utils::generate_entropy_hex());
+        }
+        catch (const std::exception &ex)
+        {
+            log_message("Failed to generate entropy: " + std::string(ex.what()), LogLevel::ERR);
+            throw std::runtime_error("Failed to generate entropy: " + std::string(ex.what()));
+        }
+        log_message("Modify: added entropy field", LogLevel::INFO);
+    }
+}
+
+void TorrentModifier::save(const std::vector<char> &buffer)
+{
+    fs::path output = config_.output.empty() ? config_.input : config_.output;
+
+    if (output == config_.input)
+    {
+        utils::atomic_write(output, buffer);
+    }
+    else
+    {
+        if (output.has_parent_path())
+        {
+            fs::create_directories(output.parent_path());
+        }
+        std::ofstream out(output, std::ios::binary);
+        if (!out)
+        {
+            throw std::runtime_error("Failed to open output file: " + output.string());
+        }
+        out.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        if (!out)
+        {
+            throw std::runtime_error("Failed to write output file: " + output.string());
+        }
+    }
+
+    print_info("Torrent saved to: " + output.string() + "\n");
+    log_message("Torrent modified successfully: " + output.string(), LogLevel::INFO);
+}
+
+std::pair<std::string, std::string> TorrentModifier::compute_hashes(const std::vector<char> &buffer) const
+{
+    std::string hash_v1;
+    std::string hash_v2;
+
+    try
+    {
+        lt::torrent_info ti(lt::span<const char>(buffer.data(), buffer.size()), lt::from_span);
+        auto hashes = ti.info_hashes();
+
+        if (hashes.has_v1())
+        {
+            std::stringstream ss;
+            ss << std::hex << std::setfill('0');
+            for (auto b : hashes.v1)
+            {
+                ss << std::setw(2) << static_cast<int>(static_cast<unsigned char>(b));
+            }
+            hash_v1 = ss.str();
+        }
+
+        if (hashes.has_v2())
+        {
+            auto v2_bytes = hashes.v2;
+            std::stringstream ss;
+            ss << std::hex << std::setfill('0');
+            for (auto b : v2_bytes)
+            {
+                ss << std::setw(2) << static_cast<int>(static_cast<unsigned char>(b));
+            }
+            hash_v2 = ss.str();
+        }
+    }
+    catch (const std::exception &e)
+    {
+        log_message("Could not compute info hash: " + std::string(e.what()), LogLevel::WARNING);
+    }
+
+    return {hash_v1, hash_v2};
+}
+
+void TorrentModifier::rebuild_trackers(lt::entry &root, const std::vector<std::string> &urls)
+{
+    if (urls.empty())
+    {
+        lt::entry::dictionary_type &dict = root.dict();
+        dict.erase("announce");
+        dict.erase("announce-list");
+        return;
+    }
+
+    root["announce"] = lt::entry(urls[0]);
+
+    lt::entry::list_type announce_list;
+    for (const auto &url : urls)
+    {
+        lt::entry::list_type tier;
+        tier.emplace_back(lt::entry(url));
+        announce_list.push_back(lt::entry(std::move(tier)));
+    }
+    root["announce-list"] = lt::entry(std::move(announce_list));
+}
+
+void TorrentModifier::add_trackers(lt::entry &root, const std::vector<std::string> &urls)
+{
+    if (urls.empty())
+    {
+        return;
+    }
+
+    lt::entry *al = root.find_key("announce-list");
+    if (al != nullptr && al->type() == lt::entry::list_t)
+    {
+        lt::entry::list_type &tiers = al->list();
+        if (!tiers.empty())
+        {
+            lt::entry::list_type &last_tier = tiers.back().list();
+            for (const auto &url : urls)
+            {
+                last_tier.emplace_back(lt::entry(url));
+            }
+        }
+        else
+        {
+            lt::entry::list_type tier;
+            for (const auto &url : urls)
+            {
+                tier.emplace_back(lt::entry(url));
+            }
+            tiers.emplace_back(lt::entry(std::move(tier)));
+        }
+    }
+    else
+    {
+        lt::entry::list_type announce_list;
+        lt::entry::list_type tier;
+        lt::entry *ann = root.find_key("announce");
+        if (ann != nullptr && ann->type() == lt::entry::string_t)
+        {
+            tier.emplace_back(lt::entry(ann->string()));
+        }
+        for (const auto &url : urls)
+        {
+            tier.emplace_back(lt::entry(url));
+        }
+        announce_list.push_back(lt::entry(std::move(tier)));
+        root["announce-list"] = lt::entry(std::move(announce_list));
+    }
+
+    lt::entry *ann = root.find_key("announce");
+    if (ann == nullptr || ann->type() != lt::entry::string_t)
+    {
+        root["announce"] = lt::entry(urls[0]);
+    }
+}
+
+std::vector<std::string> TorrentModifier::remove_url_from_tiers(lt::entry::list_type &tiers,
+                                                                  const std::vector<std::string> &urls)
+{
+    std::vector<std::string> remaining;
+
+    for (auto tier_it = tiers.begin(); tier_it != tiers.end();)
+    {
+        if (tier_it->type() != lt::entry::list_t)
+        {
+            ++tier_it;
+            continue;
+        }
+
+        lt::entry::list_type &tier_urls = tier_it->list();
+        for (auto url_it = tier_urls.begin(); url_it != tier_urls.end();)
+        {
+            if (url_it->type() == lt::entry::string_t)
+            {
+                bool matches = std::any_of(urls.begin(), urls.end(),
+                                           [&](const std::string &u)
+                                           { return url_it->string() == u; });
+                if (matches)
+                {
+                    url_it = tier_urls.erase(url_it);
+                }
+                else
+                {
+                    remaining.push_back(url_it->string());
+                    ++url_it;
+                }
+            }
+            else
+            {
+                ++url_it;
+            }
+        }
+
+        tier_it = tier_urls.empty() ? tiers.erase(tier_it) : std::next(tier_it);
+    }
+
+    return remaining;
+}
+
+void TorrentModifier::update_announce_from_remaining(lt::entry &root, const std::vector<std::string> &remaining)
+{
+    if (!remaining.empty())
+    {
+        root["announce"] = lt::entry(remaining[0]);
+    }
+    else
+    {
+        lt::entry::dictionary_type &dict = root.dict();
+        dict.erase("announce");
+    }
+}
+
+void TorrentModifier::remove_trackers(lt::entry &root, const std::vector<std::string> &urls)
+{
+    if (urls.empty())
+    {
+        return;
+    }
+
+    std::vector<std::string> remaining;
+
+    lt::entry *al = root.find_key("announce-list");
+    if (al != nullptr && al->type() == lt::entry::list_t)
+    {
+        lt::entry::list_type &tiers = al->list();
+        remaining = remove_url_from_tiers(tiers, urls);
+
+        if (tiers.empty())
+        {
+            lt::entry::dictionary_type &dict = root.dict();
+            dict.erase("announce-list");
+        }
+    }
+    else
+    {
+        lt::entry *ann = root.find_key("announce");
+        if (ann != nullptr && ann->type() == lt::entry::string_t)
+        {
+            bool matches = std::any_of(urls.begin(), urls.end(),
+                                       [&](const std::string &u)
+                                       { return ann->string() == u; });
+            if (matches)
+            {
+                lt::entry::dictionary_type &dict = root.dict();
+                dict.erase("announce");
+            }
+            else
+            {
+                remaining.push_back(ann->string());
+            }
+        }
+    }
+
+    update_announce_from_remaining(root, remaining);
+}
+
+void TorrentModifier::print_diff(const std::string &new_hash_v1, const std::string &new_hash_v2) const
+{
+    bool hash_changed = (new_hash_v1 != old_hash_v1_ || new_hash_v2 != old_hash_v2_);
+
+    if (config_.dry_run)
+    {
+        log_message("Modify: dry-run mode - no changes written", LogLevel::INFO);
+        print_info("Dry run - no changes written\n");
+    }
+
+    if (hash_changed)
+    {
+        if (!old_hash_v1_.empty() && !new_hash_v1.empty() && old_hash_v1_ != new_hash_v1)
+        {
+            print_info("Info hash v1 changed: " + old_hash_v1_ + " -> " + new_hash_v1 + "\n");
+        }
+        if (!old_hash_v2_.empty() && !new_hash_v2.empty() && old_hash_v2_ != new_hash_v2)
+        {
+            print_info("Info hash v2 changed: " + old_hash_v2_ + " -> " + new_hash_v2 + "\n");
+        }
+    }
+}

--- a/src/torrent_modifier.cpp
+++ b/src/torrent_modifier.cpp
@@ -10,6 +10,8 @@
 #include <fstream>
 #include <algorithm>
 #include <iomanip>
+#include <sstream>
+#include <libtorrent/bdecode.hpp>
 
 TorrentModifier::TorrentModifier(const ModifyConfig &config) : config_(config)
 {
@@ -19,12 +21,66 @@ void TorrentModifier::modify()
 {
     load();
 
-    lt::entry root = lt::bdecode(lt::span<const char>(raw_buffer_.data(), raw_buffer_.size()));
+    bool has_any_mod = config_.trackers.has_value() ||
+                       !config_.add_trackers.empty() ||
+                       !config_.remove_trackers.empty() ||
+                       config_.is_private.has_value() ||
+                       config_.source.has_value() ||
+                       config_.comment.has_value() ||
+                       config_.name.has_value() ||
+                       config_.entropy;
 
+    if (!has_any_mod)
+    {
+        log_message("No modifications requested", LogLevel::WARNING);
+        print_info("No modifications requested - nothing to change\n");
+        return;
+    }
+
+    bool info_modified = config_.is_private.has_value() ||
+                         config_.source.has_value() ||
+                         config_.name.has_value() ||
+                         config_.entropy;
+
+    lt::span<const char> orig_info_bytes;
+    if (!info_modified)
+    {
+        lt::bdecode_node node;
+        lt::error_code ec;
+        if (lt::bdecode(raw_buffer_.data(), raw_buffer_.data() + raw_buffer_.size(), node, ec) == 0)
+        {
+            auto info = node.dict_find("info");
+            if (info.type() == lt::bdecode_node::dict_t)
+            {
+                orig_info_bytes = info.data_section();
+            }
+        }
+    }
+
+    lt::entry root = lt::bdecode(lt::span<const char>(raw_buffer_.data(), raw_buffer_.size()));
     apply_modifications(root);
 
     std::vector<char> new_buffer;
     lt::bencode(std::back_inserter(new_buffer), root);
+
+    if (!orig_info_bytes.empty())
+    {
+        lt::bdecode_node new_node;
+        lt::error_code ec;
+        if (lt::bdecode(new_buffer.data(), new_buffer.data() + new_buffer.size(), new_node, ec) == 0)
+        {
+            auto new_info = new_node.dict_find("info");
+            if (new_info.type() == lt::bdecode_node::dict_t)
+            {
+                auto new_span = new_info.data_section();
+                if (new_span.size() == orig_info_bytes.size())
+                {
+                    std::copy(orig_info_bytes.begin(), orig_info_bytes.end(),
+                              new_buffer.begin() + (new_span.data() - new_buffer.data()));
+                }
+            }
+        }
+    }
 
     auto [new_hash_v1, new_hash_v2] = compute_hashes(new_buffer);
     print_diff(new_hash_v1, new_hash_v2);
@@ -145,27 +201,12 @@ void TorrentModifier::save(const std::vector<char> &buffer)
 {
     fs::path output = config_.output.empty() ? config_.input : config_.output;
 
-    if (output == config_.input)
+    if (output != config_.input && output.has_parent_path())
     {
-        utils::atomic_write(output, buffer);
+        fs::create_directories(output.parent_path());
     }
-    else
-    {
-        if (output.has_parent_path())
-        {
-            fs::create_directories(output.parent_path());
-        }
-        std::ofstream out(output, std::ios::binary);
-        if (!out)
-        {
-            throw std::runtime_error("Failed to open output file: " + output.string());
-        }
-        out.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
-        if (!out)
-        {
-            throw std::runtime_error("Failed to write output file: " + output.string());
-        }
-    }
+
+    utils::atomic_write(output, buffer);
 
     print_info("Torrent saved to: " + output.string() + "\n");
     log_message("Torrent modified successfully: " + output.string(), LogLevel::INFO);
@@ -225,12 +266,12 @@ void TorrentModifier::rebuild_trackers(lt::entry &root, const std::vector<std::s
     root["announce"] = lt::entry(urls[0]);
 
     lt::entry::list_type announce_list;
+    lt::entry::list_type tier;
     for (const auto &url : urls)
     {
-        lt::entry::list_type tier;
         tier.emplace_back(lt::entry(url));
-        announce_list.push_back(lt::entry(std::move(tier)));
     }
+    announce_list.push_back(lt::entry(std::move(tier)));
     root["announce-list"] = lt::entry(std::move(announce_list));
 }
 

--- a/src/torrent_modifier.cpp
+++ b/src/torrent_modifier.cpp
@@ -266,12 +266,12 @@ void TorrentModifier::rebuild_trackers(lt::entry &root, const std::vector<std::s
     root["announce"] = lt::entry(urls[0]);
 
     lt::entry::list_type announce_list;
-    lt::entry::list_type tier;
     for (const auto &url : urls)
     {
+        lt::entry::list_type tier;
         tier.emplace_back(lt::entry(url));
+        announce_list.push_back(lt::entry(std::move(tier)));
     }
-    announce_list.push_back(lt::entry(std::move(tier)));
     root["announce-list"] = lt::entry(std::move(announce_list));
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,6 +10,10 @@
 #include <vector>
 #include <chrono>
 #include <ctime>
+#include <random>
+#include <fstream>
+#include <filesystem>
+#include <unistd.h>
 
 namespace utils
 {
@@ -600,6 +604,98 @@ bool should_include_file(const std::string &relative_path,
     }
 
     return true;
+}
+
+std::string generate_entropy_hex()
+{
+    constexpr char hex_chars[] = "0123456789abcdef";
+    std::random_device rd;
+    std::uniform_int_distribution<unsigned> dist(0, 255);
+    std::string result(64, '\0');
+    for (int i = 0; i < 32; ++i)
+    {
+        unsigned byte = dist(rd);
+        result[i * 2] = hex_chars[byte >> 4];
+        result[i * 2 + 1] = hex_chars[byte & 0xF];
+    }
+    return result;
+}
+
+void direct_write(const std::filesystem::path &dest, const std::vector<char> &data)
+{
+    std::ofstream out(dest, std::ios::binary);
+    if (!out)
+    {
+        throw std::runtime_error("Failed to open output file: " + dest.string());
+    }
+    out.write(data.data(), static_cast<std::streamsize>(data.size()));
+    if (!out)
+    {
+        throw std::runtime_error("Failed to write output file: " + dest.string());
+    }
+}
+
+void atomic_write(const std::filesystem::path &dest, const std::vector<char> &data)
+{
+    namespace fs = std::filesystem;
+
+    fs::path tmp = dest;
+    tmp += ".tmp.XXXXXX";
+
+    std::string tmp_native = tmp.native();
+    int fd = mkstemp(tmp_native.data());
+    tmp = fs::path(tmp_native);
+    if (fd == -1)
+    {
+        throw std::runtime_error("Failed to create temporary file: " + tmp.string());
+    }
+
+    size_t total_written = 0;
+    while (total_written < data.size())
+    {
+        ssize_t n = write(fd, data.data() + total_written,
+                          static_cast<ssize_t>(data.size() - total_written));
+        if (n <= 0)
+        {
+            close(fd);
+            fs::remove(tmp);
+            throw std::runtime_error("Failed to write data to temporary file: " + tmp.string());
+        }
+        total_written += static_cast<size_t>(n);
+    }
+
+    if (fsync(fd) == -1)
+    {
+        close(fd);
+        fs::remove(tmp);
+        throw std::runtime_error("Failed to fsync temporary file: " + tmp.string());
+    }
+    close(fd);
+
+    std::error_code ec;
+    fs::rename(tmp, dest, ec);
+    if (ec)
+    {
+        if (ec == std::errc::cross_device_link)
+        {
+            try
+            {
+                direct_write(dest, data);
+                fs::remove(tmp);
+            }
+            catch (...)
+            {
+                fs::remove(tmp);
+                throw;
+            }
+        }
+        else
+        {
+            std::string msg = "Failed to rename temporary file: " + ec.message();
+            fs::remove(tmp);
+            throw std::runtime_error(msg);
+        }
+    }
 }
 
 } // namespace utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,7 +13,14 @@
 #include <random>
 #include <fstream>
 #include <filesystem>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#else
 #include <unistd.h>
+#endif
 
 namespace utils
 {
@@ -639,10 +646,74 @@ void atomic_write(const std::filesystem::path &dest, const std::vector<char> &da
 {
     namespace fs = std::filesystem;
 
+#ifdef _WIN32
     fs::path tmp = dest;
     tmp += ".tmp.XXXXXX";
 
-    std::string tmp_native = tmp.native();
+    std::string tmp_str = tmp.string();
+    if (_mktemp(tmp_str.data()) == nullptr)
+    {
+        throw std::runtime_error("Failed to generate temporary file name: " + tmp.string());
+    }
+    tmp = fs::path(tmp_str);
+
+    int fd = _open(tmp_str.c_str(), _O_CREAT | _O_WRONLY | _O_BINARY | _O_TRUNC, _S_IWRITE);
+    if (fd == -1)
+    {
+        throw std::runtime_error("Failed to create temporary file: " + tmp.string());
+    }
+
+    size_t total_written = 0;
+    while (total_written < data.size())
+    {
+        int n = _write(fd, data.data() + total_written,
+                       static_cast<unsigned int>(data.size() - total_written));
+        if (n <= 0)
+        {
+            _close(fd);
+            fs::remove(tmp);
+            throw std::runtime_error("Failed to write data to temporary file: " + tmp.string());
+        }
+        total_written += static_cast<size_t>(n);
+    }
+
+    if (_commit(fd) == -1)
+    {
+        _close(fd);
+        fs::remove(tmp);
+        throw std::runtime_error("Failed to flush temporary file: " + tmp.string());
+    }
+    _close(fd);
+
+    std::error_code ec;
+    fs::rename(tmp, dest, ec);
+    if (ec)
+    {
+        if (ec == std::errc::cross_device_link)
+        {
+            try
+            {
+                direct_write(dest, data);
+                fs::remove(tmp);
+            }
+            catch (...)
+            {
+                fs::remove(tmp);
+                throw;
+            }
+        }
+        else
+        {
+            std::string msg = "Failed to rename temporary file: " + ec.message();
+            fs::remove(tmp);
+            throw std::runtime_error(msg);
+        }
+    }
+#else
+    fs::path tmp = dest;
+    tmp += ".tmp.XXXXXX";
+
+    std::string tmp_native = tmp.string();
     int fd = mkstemp(tmp_native.data());
     tmp = fs::path(tmp_native);
     if (fd == -1)
@@ -696,6 +767,7 @@ void atomic_write(const std::filesystem::path &dest, const std::vector<char> &da
             throw std::runtime_error(msg);
         }
     }
+#endif
 }
 
 } // namespace utils

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -2130,3 +2130,241 @@ TEST(CLI, VersionAlwaysVisibleEvenWithQuiet) {
     EXPECT_EQ(exit_code, 0);
     EXPECT_NE(output.find("torrent_builder"), std::string::npos) << "--version should show output even with --quiet";
 }
+
+TEST(CLI, ModifyHelpShowsOptions) {
+    int exit_code;
+    std::string output = exec_command(get_binary_path() + " modify --help", exit_code);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_NE(output.find("--tracker"), std::string::npos);
+    EXPECT_NE(output.find("--add-tracker"), std::string::npos);
+    EXPECT_NE(output.find("--remove-tracker"), std::string::npos);
+    EXPECT_NE(output.find("--private"), std::string::npos);
+    EXPECT_NE(output.find("--public"), std::string::npos);
+    EXPECT_NE(output.find("--source"), std::string::npos);
+    EXPECT_NE(output.find("--comment"), std::string::npos);
+    EXPECT_NE(output.find("--name"), std::string::npos);
+    EXPECT_NE(output.find("--entropy"), std::string::npos);
+    EXPECT_NE(output.find("--dry-run"), std::string::npos);
+    EXPECT_NE(output.find("--output"), std::string::npos);
+}
+
+TEST(CLI, ModifyNoArgsShowsHelp) {
+    int exit_code;
+    std::string output = exec_command(get_binary_path() + " modify 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_NE(output.find("Modify torrent metadata"), std::string::npos);
+}
+
+TEST(CLI, ModifyTrackerConflict) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "tb_modify_conflict";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    { std::ofstream(input_file) << "test content"; }
+    auto torrent_file = temp_dir / "input.torrent";
+    int create_exit;
+    exec_command(get_binary_path() + " --path " + input_file.string()
+        + " --output " + torrent_file.string() + " --torrent-version 1 2>&1", create_exit);
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " modify " + torrent_file.string()
+        + " --tracker \"https://t1.com/announce\""
+        + " --add-tracker \"https://t2.com/announce\" 2>&1", exit_code);
+
+    EXPECT_NE(exit_code, 0);
+    EXPECT_NE(output.find("exclusive"), std::string::npos) << "Output: " << output;
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, ModifyPrivatePublicConflict) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "tb_modify_pp_conflict";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    { std::ofstream(input_file) << "test content"; }
+    auto torrent_file = temp_dir / "input.torrent";
+    int create_exit;
+    exec_command(get_binary_path() + " --path " + input_file.string()
+        + " --output " + torrent_file.string() + " --torrent-version 1 2>&1", create_exit);
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " modify " + torrent_file.string()
+        + " --private --public 2>&1", exit_code);
+
+    EXPECT_NE(exit_code, 0);
+    EXPECT_NE(output.find("mutually exclusive"), std::string::npos) << "Output: " << output;
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, ModifyNoModificationOption) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "tb_modify_nomod";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    { std::ofstream(input_file) << "test content"; }
+    auto torrent_file = temp_dir / "input.torrent";
+    int create_exit;
+    exec_command(get_binary_path() + " --path " + input_file.string()
+        + " --output " + torrent_file.string() + " --torrent-version 1 2>&1", create_exit);
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " modify " + torrent_file.string() + " 2>&1", exit_code);
+
+    EXPECT_NE(exit_code, 0);
+    EXPECT_NE(output.find("at least one modification"), std::string::npos) << "Output: " << output;
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, ModifyTrackerReplaceEndToEnd) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "tb_modify_tracker";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    { std::ofstream(input_file) << "test content"; }
+    auto torrent_file = temp_dir / "input.torrent";
+    auto output_file = temp_dir / "modified.torrent";
+    int create_exit;
+    exec_command(get_binary_path() + " --path " + input_file.string()
+        + " --output " + torrent_file.string() + " --torrent-version 1 2>&1", create_exit);
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " modify " + torrent_file.string()
+        + " --tracker \"https://new-tracker.example.com/announce\""
+        + " --output " + output_file.string() + " 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    ASSERT_EQ(meta.trackers.size(), 1u);
+    EXPECT_EQ(meta.trackers[0], "https://new-tracker.example.com/announce");
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, ModifySourceEndToEnd) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "tb_modify_source";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    { std::ofstream(input_file) << "test content"; }
+    auto torrent_file = temp_dir / "input.torrent";
+    auto output_file = temp_dir / "modified.torrent";
+    int create_exit;
+    exec_command(get_binary_path() + " --path " + input_file.string()
+        + " --output " + torrent_file.string() + " --torrent-version 1 2>&1", create_exit);
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " modify " + torrent_file.string()
+        + " --source PTP --output " + output_file.string() + " 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    ASSERT_TRUE(meta.source.has_value());
+    EXPECT_EQ(*meta.source, "PTP");
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, ModifyPrivateEndToEnd) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "tb_modify_private";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    { std::ofstream(input_file) << "test content"; }
+    auto torrent_file = temp_dir / "input.torrent";
+    auto output_file = temp_dir / "modified.torrent";
+    int create_exit;
+    exec_command(get_binary_path() + " --path " + input_file.string()
+        + " --output " + torrent_file.string() + " --torrent-version 1 2>&1", create_exit);
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " modify " + torrent_file.string()
+        + " --private --output " + output_file.string() + " 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_TRUE(meta.is_private);
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, ModifyDryRunNoFileWritten) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "tb_modify_dryrun";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    { std::ofstream(input_file) << "test content"; }
+    auto torrent_file = temp_dir / "input.torrent";
+    auto output_file = temp_dir / "should_not_exist.torrent";
+    int create_exit;
+    exec_command(get_binary_path() + " --path " + input_file.string()
+        + " --output " + torrent_file.string() + " --torrent-version 1 2>&1", create_exit);
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " modify " + torrent_file.string()
+        + " --source TEST --output " + output_file.string()
+        + " --dry-run 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_NE(output.find("Dry run"), std::string::npos) << "Output: " << output;
+    EXPECT_FALSE(fs::exists(output_file));
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(CLI, ModifyEntropyEndToEnd) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "tb_modify_entropy";
+    fs::create_directories(temp_dir);
+    auto input_file = temp_dir / "input.txt";
+    { std::ofstream(input_file) << "test content"; }
+    auto torrent_file = temp_dir / "input.torrent";
+    auto output_file = temp_dir / "modified.torrent";
+    int create_exit;
+    exec_command(get_binary_path() + " --path " + input_file.string()
+        + " --output " + torrent_file.string() + " --torrent-version 1 2>&1", create_exit);
+
+    TorrentInspector orig(torrent_file.string());
+    auto orig_meta = orig.inspect();
+
+    int exit_code;
+    std::string output = exec_command(
+        get_binary_path() + " modify " + torrent_file.string()
+        + " --entropy --output " + output_file.string() + " 2>&1", exit_code);
+
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector(output_file.string());
+    TorrentMetadata meta = inspector.inspect();
+    ASSERT_TRUE(meta.entropy.has_value());
+    EXPECT_EQ(meta.entropy->size(), 64u);
+    if (!orig_meta.info_hash_v1.empty() && !meta.info_hash_v1.empty())
+    {
+        EXPECT_NE(orig_meta.info_hash_v1, meta.info_hash_v1);
+    }
+
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}

--- a/tests/test_modifier.cpp
+++ b/tests/test_modifier.cpp
@@ -1,0 +1,798 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <libtorrent/create_torrent.hpp>
+#include <libtorrent/torrent_info.hpp>
+#include <libtorrent/file_storage.hpp>
+#include <libtorrent/bencode.hpp>
+#include <libtorrent/entry.hpp>
+#include <libtorrent/hash_picker.hpp>
+#include "torrent_modifier.hpp"
+#include "torrent_inspector.hpp"
+#include "utils.hpp"
+
+namespace fs = std::filesystem;
+
+class ModifierTest : public ::testing::Test
+{
+  protected:
+    fs::path test_dir_;
+    fs::path test_file_;
+    fs::path torrent_path_;
+
+    void SetUp() override
+    {
+        test_dir_ = fs::current_path() / "modifier_test_tmp";
+        fs::create_directories(test_dir_);
+        test_file_ = test_dir_ / "test_file.txt";
+        create_test_file();
+        torrent_path_ = test_dir_ / "test.torrent";
+        create_simple_torrent();
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        fs::remove_all(test_dir_, ec);
+    }
+
+    void create_test_file()
+    {
+        std::ofstream file(test_file_);
+        file << "Hello World - test content for torrent modifier";
+        file.close();
+    }
+
+    void create_simple_torrent(const std::string &tracker = "udp://tracker.example.com:80/announce")
+    {
+        create_test_file();
+
+        lt::file_storage fs;
+        fs.add_file("test_file.txt", static_cast<std::int64_t>(std::filesystem::file_size(test_file_)));
+        lt::create_torrent ct(fs, 16384, lt::create_torrent::v1_only);
+
+        std::ifstream data_file(test_file_, std::ios::binary);
+        std::vector<char> file_data((std::istreambuf_iterator<char>(data_file)),
+                                     std::istreambuf_iterator<char>());
+        auto piece_hash = lt::hasher(lt::span<char const>(file_data.data(), file_data.size())).final();
+        ct.set_hash(0, piece_hash);
+
+        if (!tracker.empty())
+        {
+            ct.add_tracker(tracker);
+        }
+
+        lt::entry e = ct.generate();
+        std::vector<char> buffer;
+        lt::bencode(std::back_inserter(buffer), e);
+
+        std::ofstream torrent(torrent_path_, std::ios::binary);
+        torrent.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        torrent.close();
+    }
+
+    TorrentMetadata read_torrent_metadata(const fs::path &path)
+    {
+        TorrentInspector inspector(path.string());
+        return inspector.inspect();
+    }
+
+    std::vector<char> read_file_bytes(const fs::path &path)
+    {
+        std::ifstream file(path, std::ios::binary);
+        return std::vector<char>((std::istreambuf_iterator<char>(file)),
+                                  std::istreambuf_iterator<char>());
+    }
+};
+
+TEST_F(ModifierTest, TrackerReplace)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.trackers = {"https://new-tracker.example.com/announce"};
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    ASSERT_EQ(meta.trackers.size(), 1u);
+    EXPECT_EQ(meta.trackers[0], "https://new-tracker.example.com/announce");
+}
+
+TEST_F(ModifierTest, TrackerAdd)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.add_trackers = {"https://new-tracker.example.com/announce"};
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    EXPECT_GE(meta.trackers.size(), 2u);
+
+    bool found_new = false;
+    bool found_old = false;
+    for (const auto &t : meta.trackers)
+    {
+        if (t == "https://new-tracker.example.com/announce")
+            found_new = true;
+        if (t == "udp://tracker.example.com:80/announce")
+            found_old = true;
+    }
+    EXPECT_TRUE(found_new);
+    EXPECT_TRUE(found_old);
+}
+
+TEST_F(ModifierTest, TrackerRemove)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.remove_trackers = {"udp://tracker.example.com:80/announce"};
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    for (const auto &t : meta.trackers)
+    {
+        EXPECT_NE(t, "udp://tracker.example.com:80/announce");
+    }
+}
+
+TEST_F(ModifierTest, TogglePrivateOn)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.is_private = true;
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    EXPECT_TRUE(meta.is_private);
+}
+
+TEST_F(ModifierTest, TogglePrivateOff)
+{
+    {
+        ModifyConfig setup_config;
+        setup_config.input = torrent_path_;
+        setup_config.output = torrent_path_;
+        setup_config.is_private = true;
+        TorrentModifier(setup_config).modify();
+    }
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.is_private = false;
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    EXPECT_FALSE(meta.is_private);
+}
+
+TEST_F(ModifierTest, SetSource)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.source = "PTP";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    ASSERT_TRUE(meta.source.has_value());
+    EXPECT_EQ(meta.source.value(), "PTP");
+}
+
+TEST_F(ModifierTest, RemoveSource)
+{
+    {
+        ModifyConfig setup_config;
+        setup_config.input = torrent_path_;
+        setup_config.output = torrent_path_;
+        setup_config.source = "PTP";
+        TorrentModifier(setup_config).modify();
+    }
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.source = "";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    EXPECT_FALSE(meta.source.has_value());
+}
+
+TEST_F(ModifierTest, SetComment)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.comment = "Updated comment";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    ASSERT_TRUE(meta.comment.has_value());
+    EXPECT_EQ(meta.comment.value(), "Updated comment");
+}
+
+TEST_F(ModifierTest, ChangeName)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.name = "New Torrent Name";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    EXPECT_EQ(meta.name, "New Torrent Name");
+}
+
+TEST_F(ModifierTest, EntropyChangesInfoHash)
+{
+    auto original_meta = read_torrent_metadata(torrent_path_);
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.entropy = true;
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto new_meta = read_torrent_metadata(config.output);
+
+    if (!original_meta.info_hash_v1.empty() && !new_meta.info_hash_v1.empty())
+    {
+        EXPECT_NE(original_meta.info_hash_v1, new_meta.info_hash_v1);
+    }
+}
+
+TEST_F(ModifierTest, DryRunNoFileWritten)
+{
+    fs::path output_path = test_dir_ / "should_not_exist.torrent";
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = output_path;
+    config.dry_run = true;
+    config.source = "TEST";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    EXPECT_FALSE(fs::exists(output_path));
+}
+
+TEST_F(ModifierTest, InPlaceModify)
+{
+    auto original_bytes = read_file_bytes(torrent_path_);
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.source = "INPLACE";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(torrent_path_);
+    ASSERT_TRUE(meta.source.has_value());
+    EXPECT_EQ(meta.source.value(), "INPLACE");
+
+    auto new_bytes = read_file_bytes(torrent_path_);
+    EXPECT_NE(original_bytes.size(), 0u);
+    EXPECT_NE(original_bytes, new_bytes);
+}
+
+TEST_F(ModifierTest, OutputToDifferentFile)
+{
+    auto original_bytes = read_file_bytes(torrent_path_);
+    fs::path output_path = test_dir_ / "modified.torrent";
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = output_path;
+    config.source = "NEWFILE";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    EXPECT_TRUE(fs::exists(output_path));
+
+    auto original_meta = read_torrent_metadata(torrent_path_);
+    EXPECT_FALSE(original_meta.source.has_value());
+
+    auto new_meta = read_torrent_metadata(output_path);
+    ASSERT_TRUE(new_meta.source.has_value());
+    EXPECT_EQ(new_meta.source.value(), "NEWFILE");
+}
+
+TEST_F(ModifierTest, InvalidInputThrows)
+{
+    ModifyConfig config;
+    config.input = test_dir_ / "nonexistent.torrent";
+    config.source = "TEST";
+
+    TorrentModifier modifier(config);
+    EXPECT_THROW(modifier.modify(), std::runtime_error);
+}
+
+TEST_F(ModifierTest, RemoveAllTrackers)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.remove_trackers = {"udp://tracker.example.com:80/announce"};
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto new_bytes = read_file_bytes(test_dir_ / "modified.torrent");
+    lt::entry root = lt::bdecode(lt::span<const char>(new_bytes.data(), new_bytes.size()));
+
+    EXPECT_EQ(root.find_key("announce"), nullptr);
+    EXPECT_EQ(root.find_key("announce-list"), nullptr);
+}
+
+TEST_F(ModifierTest, PreservesFileData)
+{
+    auto original_meta = read_torrent_metadata(torrent_path_);
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.source = "TEST";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto new_meta = read_torrent_metadata(config.output);
+    EXPECT_EQ(original_meta.total_size, new_meta.total_size);
+    EXPECT_EQ(original_meta.piece_length, new_meta.piece_length);
+    EXPECT_EQ(original_meta.piece_count, new_meta.piece_count);
+    EXPECT_EQ(original_meta.files.size(), new_meta.files.size());
+    if (!original_meta.files.empty() && !new_meta.files.empty())
+    {
+        EXPECT_EQ(original_meta.files[0].path, new_meta.files[0].path);
+        EXPECT_EQ(original_meta.files[0].size, new_meta.files[0].size);
+    }
+}
+
+TEST_F(ModifierTest, MultipleModifications)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.trackers = {"https://new.example.com/announce"};
+    config.is_private = true;
+    config.source = "MULTI";
+    config.comment = "Multi test";
+    config.name = "MultiName";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    ASSERT_EQ(meta.trackers.size(), 1u);
+    EXPECT_EQ(meta.trackers[0], "https://new.example.com/announce");
+    EXPECT_TRUE(meta.is_private);
+    ASSERT_TRUE(meta.source.has_value());
+    EXPECT_EQ(meta.source.value(), "MULTI");
+    ASSERT_TRUE(meta.comment.has_value());
+    EXPECT_EQ(meta.comment.value(), "Multi test");
+    EXPECT_EQ(meta.name, "MultiName");
+}
+
+TEST_F(ModifierTest, TrackerReplaceWithMultiple)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.trackers = {"https://t1.example.com/announce", "https://t2.example.com/announce"};
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    ASSERT_EQ(meta.trackers.size(), 2u);
+    EXPECT_EQ(meta.trackers[0], "https://t1.example.com/announce");
+    EXPECT_EQ(meta.trackers[1], "https://t2.example.com/announce");
+}
+
+TEST_F(ModifierTest, PartialTrackerRemovalUpdatesAnnounce)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.trackers = {"https://keep.example.com/announce", "https://remove.example.com/announce"};
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto first_meta = read_torrent_metadata(config.output);
+    ASSERT_EQ(first_meta.trackers.size(), 2u);
+
+    ModifyConfig config2;
+    config2.input = config.output;
+    config2.output = test_dir_ / "modified2.torrent";
+    config2.remove_trackers = {"https://remove.example.com/announce"};
+
+    TorrentModifier modifier2(config2);
+    modifier2.modify();
+
+    auto second_meta = read_torrent_metadata(config2.output);
+    ASSERT_EQ(second_meta.trackers.size(), 1u);
+    EXPECT_EQ(second_meta.trackers[0], "https://keep.example.com/announce");
+}
+
+TEST_F(ModifierTest, ChangeSourcePreservesInfoHashOnNoInfoChange)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.comment = "Only comment changes";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto original_meta = read_torrent_metadata(torrent_path_);
+    auto new_meta = read_torrent_metadata(config.output);
+
+    if (!original_meta.info_hash_v1.empty() && !new_meta.info_hash_v1.empty())
+    {
+        EXPECT_EQ(original_meta.info_hash_v1, new_meta.info_hash_v1);
+    }
+}
+
+TEST_F(ModifierTest, GenerateEntropyHexProducesUniqueValues)
+{
+    std::string first = utils::generate_entropy_hex();
+    std::string second = utils::generate_entropy_hex();
+    EXPECT_NE(first, second);
+    EXPECT_EQ(first.size(), 64u);
+    EXPECT_EQ(second.size(), 64u);
+}
+
+TEST_F(ModifierTest, RemoveComment)
+{
+    {
+        ModifyConfig setup_config;
+        setup_config.input = torrent_path_;
+        setup_config.output = torrent_path_;
+        setup_config.comment = "Temporary comment";
+        TorrentModifier(setup_config).modify();
+    }
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.comment = "";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    EXPECT_FALSE(meta.comment.has_value());
+}
+
+TEST_F(ModifierTest, RebuildTrackersWithEmptyList)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.trackers = std::vector<std::string>{};
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto new_bytes = read_file_bytes(config.output);
+    lt::entry root = lt::bdecode(lt::span<const char>(new_bytes.data(), new_bytes.size()));
+
+    EXPECT_EQ(root.find_key("announce"), nullptr);
+    EXPECT_EQ(root.find_key("announce-list"), nullptr);
+}
+
+TEST_F(ModifierTest, AddTrackersToAnnounceOnlyTorrent)
+{
+    lt::entry root;
+    root["info"]["name"] = lt::entry("test");
+    root["info"]["piece length"] = lt::entry(16384);
+    root["announce"] = lt::entry("udp://original.example.com:80/announce");
+
+    std::vector<char> buffer;
+    lt::bencode(std::back_inserter(buffer), root);
+    std::ofstream out(torrent_path_, std::ios::binary);
+    out.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    out.close();
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.add_trackers = {"https://new-tracker.example.com/announce"};
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto new_bytes = read_file_bytes(config.output);
+    lt::entry modified = lt::bdecode(lt::span<const char>(new_bytes.data(), new_bytes.size()));
+
+    lt::entry *ann = modified.find_key("announce");
+    ASSERT_NE(ann, nullptr);
+    EXPECT_EQ(ann->string(), "udp://original.example.com:80/announce");
+
+    lt::entry *al = modified.find_key("announce-list");
+    ASSERT_NE(al, nullptr);
+    auto &tiers = al->list();
+    ASSERT_EQ(tiers.size(), 1u);
+    auto &tier = tiers[0].list();
+    EXPECT_EQ(tier.size(), 2u);
+    EXPECT_EQ(tier[0].string(), "udp://original.example.com:80/announce");
+    EXPECT_EQ(tier[1].string(), "https://new-tracker.example.com/announce");
+}
+
+TEST_F(ModifierTest, RemoveTrackersFromAnnounceOnlyTorrent)
+{
+    lt::entry root;
+    root["info"]["name"] = lt::entry("test");
+    root["info"]["piece length"] = lt::entry(16384);
+    root["announce"] = lt::entry("udp://tracker.example.com:80/announce");
+
+    std::vector<char> buffer;
+    lt::bencode(std::back_inserter(buffer), root);
+    std::ofstream out(torrent_path_, std::ios::binary);
+    out.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    out.close();
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.remove_trackers = {"udp://tracker.example.com:80/announce"};
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto new_bytes = read_file_bytes(config.output);
+    lt::entry modified = lt::bdecode(lt::span<const char>(new_bytes.data(), new_bytes.size()));
+
+    EXPECT_EQ(modified.find_key("announce"), nullptr);
+    EXPECT_EQ(modified.find_key("announce-list"), nullptr);
+}
+
+TEST_F(ModifierTest, MissingInfoDictThrows)
+{
+    lt::entry root;
+    root["comment"] = lt::entry("no info dict");
+
+    std::vector<char> buffer;
+    lt::bencode(std::back_inserter(buffer), root);
+    std::ofstream out(torrent_path_, std::ios::binary);
+    out.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    out.close();
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.source = "TEST";
+
+    TorrentModifier modifier(config);
+    EXPECT_THROW(modifier.modify(), std::runtime_error);
+}
+
+TEST_F(ModifierTest, EmptyFileThrows)
+{
+    std::ofstream out(torrent_path_, std::ios::binary);
+    out.close();
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.source = "TEST";
+
+    TorrentModifier modifier(config);
+    EXPECT_THROW(modifier.modify(), std::runtime_error);
+}
+
+TEST_F(ModifierTest, NoOpPreservesInfoHash)
+{
+    auto original_meta = read_torrent_metadata(torrent_path_);
+    auto original_bytes = read_file_bytes(torrent_path_);
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.comment = "only comment changes, not info dict";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto new_meta = read_torrent_metadata(config.output);
+
+    if (!original_meta.info_hash_v1.empty() && !new_meta.info_hash_v1.empty())
+    {
+        EXPECT_EQ(original_meta.info_hash_v1, new_meta.info_hash_v1);
+    }
+    EXPECT_EQ(original_meta.total_size, new_meta.total_size);
+    EXPECT_EQ(original_meta.files.size(), new_meta.files.size());
+}
+
+TEST_F(ModifierTest, SaveToNewDirectory)
+{
+    fs::path nested = test_dir_ / "nested" / "output";
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = nested / "modified.torrent";
+    config.source = "NESTED";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    EXPECT_TRUE(fs::exists(config.output));
+    auto meta = read_torrent_metadata(config.output);
+    ASSERT_TRUE(meta.source.has_value());
+    EXPECT_EQ(meta.source.value(), "NESTED");
+}
+
+class V2ModifierTest : public ::testing::Test
+{
+  protected:
+    fs::path test_dir_;
+    fs::path test_file_;
+    fs::path torrent_path_;
+
+    void SetUp() override
+    {
+        test_dir_ = fs::current_path() / "v2_modifier_test_tmp";
+        fs::create_directories(test_dir_);
+        test_file_ = test_dir_ / "test_file.txt";
+        std::ofstream file(test_file_);
+        file << "Hello World - v2 test content";
+        file.close();
+
+        torrent_path_ = test_dir_ / "test.torrent";
+
+        lt::file_storage fs;
+        fs.add_file("test_file.txt", static_cast<std::int64_t>(std::filesystem::file_size(test_file_)));
+        lt::create_torrent ct(fs, 16384, lt::create_torrent::v2_only);
+
+        lt::set_piece_hashes(ct, test_dir_.string());
+
+        lt::entry e = ct.generate();
+        std::vector<char> buffer;
+        lt::bencode(std::back_inserter(buffer), e);
+        std::ofstream torrent(torrent_path_, std::ios::binary);
+        torrent.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        torrent.close();
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        fs::remove_all(test_dir_, ec);
+    }
+
+    TorrentMetadata read_torrent_metadata(const fs::path &path)
+    {
+        TorrentInspector inspector(path.string());
+        return inspector.inspect();
+    }
+};
+
+TEST_F(V2ModifierTest, ModifySourcePreservesFileTree)
+{
+    auto original_meta = read_torrent_metadata(torrent_path_);
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.source = "V2TEST";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto new_meta = read_torrent_metadata(config.output);
+    ASSERT_TRUE(new_meta.source.has_value());
+    EXPECT_EQ(new_meta.source.value(), "V2TEST");
+    EXPECT_EQ(original_meta.total_size, new_meta.total_size);
+    EXPECT_EQ(original_meta.files.size(), new_meta.files.size());
+    EXPECT_FALSE(new_meta.info_hash_v2.empty());
+}
+
+TEST_F(V2ModifierTest, ModifyPrivateFlag)
+{
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.is_private = true;
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto meta = read_torrent_metadata(config.output);
+    EXPECT_TRUE(meta.is_private);
+}
+
+class HybridModifierTest : public ::testing::Test
+{
+  protected:
+    fs::path test_dir_;
+    fs::path content_dir_;
+    fs::path torrent_path_;
+
+    void SetUp() override
+    {
+        test_dir_ = fs::current_path() / "hybrid_modifier_test_tmp";
+        fs::create_directories(test_dir_);
+        content_dir_ = test_dir_ / "content";
+        fs::create_directories(content_dir_);
+        std::ofstream(content_dir_ / "file1.txt") << "hybrid test file 1";
+        std::ofstream(content_dir_ / "file2.txt") << "hybrid test file 2";
+
+        torrent_path_ = test_dir_ / "test.torrent";
+
+        lt::file_storage fs;
+        lt::add_files(fs, content_dir_.string());
+
+        lt::create_torrent ct(fs, 16384);
+
+        lt::set_piece_hashes(ct, test_dir_.string());
+
+        lt::entry e = ct.generate();
+        std::vector<char> buffer;
+        lt::bencode(std::back_inserter(buffer), e);
+        std::ofstream torrent(torrent_path_, std::ios::binary);
+        torrent.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        torrent.close();
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        fs::remove_all(test_dir_, ec);
+    }
+
+    TorrentMetadata read_torrent_metadata(const fs::path &path)
+    {
+        TorrentInspector inspector(path.string());
+        return inspector.inspect();
+    }
+};
+
+TEST_F(HybridModifierTest, ModifySourcePreservesBothStructures)
+{
+    auto original_meta = read_torrent_metadata(torrent_path_);
+    ASSERT_TRUE(original_meta.is_hybrid);
+
+    ModifyConfig config;
+    config.input = torrent_path_;
+    config.output = test_dir_ / "modified.torrent";
+    config.source = "HYBRID";
+
+    TorrentModifier modifier(config);
+    modifier.modify();
+
+    auto new_meta = read_torrent_metadata(config.output);
+    ASSERT_TRUE(new_meta.source.has_value());
+    EXPECT_EQ(new_meta.source.value(), "HYBRID");
+    EXPECT_TRUE(new_meta.is_hybrid);
+    EXPECT_EQ(original_meta.total_size, new_meta.total_size);
+    EXPECT_EQ(original_meta.files.size(), new_meta.files.size());
+    EXPECT_FALSE(new_meta.info_hash_v1.empty());
+    EXPECT_FALSE(new_meta.info_hash_v2.empty());
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -2,6 +2,7 @@
 #include "utils.hpp"
 #include "constants.hpp"
 #include <fstream>
+#include <filesystem>
 
 TEST(AutoPieceSize, ZeroBytes) {
     EXPECT_EQ(utils::auto_piece_size(0), PieceSizes::k16KB);
@@ -1015,4 +1016,193 @@ TEST(GlobToRegex, TrailingSlashPattern) {
     EXPECT_TRUE(std::regex_match("dir/", re));
     EXPECT_FALSE(std::regex_match("dir", re));
     EXPECT_FALSE(std::regex_match("dir/file.txt", re));
+}
+
+TEST(AtomicWrite, CreatesFileWithCorrectContent) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_atomic_write";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "output.bin";
+
+    std::vector<char> data = {'H', 'e', 'l', 'l', 'o'};
+    utils::atomic_write(dest, data);
+
+    ASSERT_TRUE(fs::exists(dest));
+    std::ifstream in(dest, std::ios::binary);
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, "Hello");
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(AtomicWrite, OverwritesExistingFile) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_atomic_overwrite";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "output.bin";
+
+    { std::ofstream(dest) << "old content"; }
+    ASSERT_TRUE(fs::exists(dest));
+
+    std::vector<char> data = {'n', 'e', 'w'};
+    utils::atomic_write(dest, data);
+
+    std::ifstream in(dest, std::ios::binary);
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, "new");
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(AtomicWrite, NoTempFileLeftOnSuccess) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_atomic_no_tmp";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "output.bin";
+
+    std::vector<char> data = {'d', 'a', 't', 'a'};
+    utils::atomic_write(dest, data);
+
+    int tmp_count = 0;
+    for (const auto &entry : fs::directory_iterator(temp_dir))
+    {
+        if (entry.path().string().find(".tmp.") != std::string::npos)
+            ++tmp_count;
+    }
+    EXPECT_EQ(tmp_count, 0);
+    EXPECT_TRUE(fs::exists(dest));
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(AtomicWrite, EmptyDataCreatesEmptyFile) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_atomic_empty";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "empty.bin";
+
+    std::vector<char> data;
+    utils::atomic_write(dest, data);
+
+    ASSERT_TRUE(fs::exists(dest));
+    EXPECT_EQ(fs::file_size(dest), 0u);
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(AtomicWrite, ThrowsOnInvalidPath) {
+    std::vector<char> data = {'x'};
+    EXPECT_THROW(utils::atomic_write("/nonexistent/deep/dir/file.bin", data), std::runtime_error);
+}
+
+TEST(AtomicWrite, BinaryDataPreserved) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_atomic_binary";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "binary.bin";
+
+    std::vector<char> data(256);
+    for (int i = 0; i < 256; ++i)
+        data[i] = static_cast<char>(i);
+
+    utils::atomic_write(dest, data);
+
+    std::ifstream in(dest, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data.size(), data.size());
+    EXPECT_EQ(read_data, data);
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(DirectWrite, CreatesFileWithCorrectContent) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_direct_write";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "output.bin";
+
+    std::vector<char> data = {'H', 'e', 'l', 'l', 'o'};
+    utils::direct_write(dest, data);
+
+    ASSERT_TRUE(fs::exists(dest));
+    std::ifstream in(dest, std::ios::binary);
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, "Hello");
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(DirectWrite, OverwritesExistingFile) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_direct_overwrite";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "output.bin";
+
+    { std::ofstream(dest) << "old content"; }
+
+    std::vector<char> data = {'n', 'e', 'w'};
+    utils::direct_write(dest, data);
+
+    std::ifstream in(dest, std::ios::binary);
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, "new");
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(DirectWrite, CreatesParentDirectoriesIfNeeded) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_direct_nested";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "sub" / "dir" / "output.bin";
+    fs::create_directories(dest.parent_path());
+
+    std::vector<char> data = {'d', 'a', 't', 'a'};
+    utils::direct_write(dest, data);
+
+    ASSERT_TRUE(fs::exists(dest));
+    std::ifstream in(dest, std::ios::binary);
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, "data");
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(DirectWrite, ThrowsOnInvalidPath) {
+    std::vector<char> data = {'x'};
+    EXPECT_THROW(utils::direct_write("/nonexistent/deep/dir/file.bin", data), std::runtime_error);
+}
+
+TEST(DirectWrite, BinaryDataPreserved) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_direct_binary";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "binary.bin";
+
+    std::vector<char> data(256);
+    for (int i = 0; i < 256; ++i)
+        data[i] = static_cast<char>(i);
+
+    utils::direct_write(dest, data);
+
+    std::ifstream in(dest, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data, data);
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(DirectWrite, EmptyDataCreatesEmptyFile) {
+    namespace fs = std::filesystem;
+    auto temp_dir = fs::temp_directory_path() / "torrent_builder_direct_empty";
+    fs::create_directories(temp_dir);
+    auto dest = temp_dir / "empty.bin";
+
+    std::vector<char> data;
+    utils::direct_write(dest, data);
+
+    ASSERT_TRUE(fs::exists(dest));
+    EXPECT_EQ(fs::file_size(dest), 0u);
+
+    fs::remove_all(temp_dir);
 }

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1028,9 +1028,12 @@ TEST(AtomicWrite, CreatesFileWithCorrectContent) {
     utils::atomic_write(dest, data);
 
     ASSERT_TRUE(fs::exists(dest));
-    std::ifstream in(dest, std::ios::binary);
-    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(contents, "Hello");
+    {
+        std::ifstream in(dest, std::ios::binary);
+        std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        EXPECT_EQ(contents, "Hello");
+        in.close();
+    }
 
     fs::remove_all(temp_dir);
 }
@@ -1047,9 +1050,12 @@ TEST(AtomicWrite, OverwritesExistingFile) {
     std::vector<char> data = {'n', 'e', 'w'};
     utils::atomic_write(dest, data);
 
-    std::ifstream in(dest, std::ios::binary);
-    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(contents, "new");
+    {
+        std::ifstream in(dest, std::ios::binary);
+        std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        EXPECT_EQ(contents, "new");
+        in.close();
+    }
 
     fs::remove_all(temp_dir);
 }
@@ -1107,10 +1113,13 @@ TEST(AtomicWrite, BinaryDataPreserved) {
 
     utils::atomic_write(dest, data);
 
-    std::ifstream in(dest, std::ios::binary);
-    std::vector<char> read_data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(read_data.size(), data.size());
-    EXPECT_EQ(read_data, data);
+    {
+        std::ifstream in(dest, std::ios::binary);
+        std::vector<char> read_data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        EXPECT_EQ(read_data.size(), data.size());
+        EXPECT_EQ(read_data, data);
+        in.close();
+    }
 
     fs::remove_all(temp_dir);
 }
@@ -1125,9 +1134,12 @@ TEST(DirectWrite, CreatesFileWithCorrectContent) {
     utils::direct_write(dest, data);
 
     ASSERT_TRUE(fs::exists(dest));
-    std::ifstream in(dest, std::ios::binary);
-    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(contents, "Hello");
+    {
+        std::ifstream in(dest, std::ios::binary);
+        std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        EXPECT_EQ(contents, "Hello");
+        in.close();
+    }
 
     fs::remove_all(temp_dir);
 }
@@ -1143,9 +1155,12 @@ TEST(DirectWrite, OverwritesExistingFile) {
     std::vector<char> data = {'n', 'e', 'w'};
     utils::direct_write(dest, data);
 
-    std::ifstream in(dest, std::ios::binary);
-    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(contents, "new");
+    {
+        std::ifstream in(dest, std::ios::binary);
+        std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        EXPECT_EQ(contents, "new");
+        in.close();
+    }
 
     fs::remove_all(temp_dir);
 }
@@ -1161,9 +1176,12 @@ TEST(DirectWrite, CreatesParentDirectoriesIfNeeded) {
     utils::direct_write(dest, data);
 
     ASSERT_TRUE(fs::exists(dest));
-    std::ifstream in(dest, std::ios::binary);
-    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(contents, "data");
+    {
+        std::ifstream in(dest, std::ios::binary);
+        std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        EXPECT_EQ(contents, "data");
+        in.close();
+    }
 
     fs::remove_all(temp_dir);
 }
@@ -1185,9 +1203,12 @@ TEST(DirectWrite, BinaryDataPreserved) {
 
     utils::direct_write(dest, data);
 
-    std::ifstream in(dest, std::ios::binary);
-    std::vector<char> read_data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(read_data, data);
+    {
+        std::ifstream in(dest, std::ios::binary);
+        std::vector<char> read_data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        EXPECT_EQ(read_data, data);
+        in.close();
+    }
 
     fs::remove_all(temp_dir);
 }


### PR DESCRIPTION
## Summary

Add a `modify` subcommand to `torrent_builder` that allows users to edit metadata of existing `.torrent` files — including trackers, private flag, source, comment, name, and entropy injection — without rebuilding the torrent from scratch.

## Motivation

Previously, the only way to change metadata (e.g., update a tracker URL, set a source tag for a private tracker, or add entropy to anonymize a torrent) was to re-create the entire torrent from source files. This is impractical for large torrents, unreproducible builds, or workflows where the original content is no longer available. The `modify` subcommand enables fast, safe, in-place or out-of-place metadata edits by directly manipulating the bencoded structure.

## Changes Made

- **Entropy generation extracted to shared utils** — `generate_entropy_hex()` moved from `torrent_creator.cpp` to `utils.hpp`/`utils.cpp` so both creator and modifier use the same entropy source.
- **Atomic and direct write utilities** — `atomic_write()` writes via `mkstemp` + `fsync` + write retry loop + `rename` with cross-device fallback to `direct_write()` (`ofstream`). Ensures no partial/corrupt output on crash.
- **`TorrentModifier` class** — loads a `.torrent` file, decodes the bencoded tree, applies requested modifications, computes V1/V2 info hashes, prints a diff of changed hashes, and atomically writes the result.
- **Supported modification operations:**
  - Replace trackers (`--tracker`), add trackers (`--add-tracker`), remove trackers (`--remove-tracker`)
  - Toggle private flag (`--private` / `--public`)
  - Set or clear source (`--source`), comment (`--comment`), name (`--name`)
  - Inject entropy into the info dict (`--entropy`) to produce a new info hash
  - Dry-run mode (`--dry-run`) that shows what would change without writing
  - In-place modification (input == output) or out-of-place (`--output`)
- **CLI dispatch** — `handle_modify_command()` with cxxopts argument parsing, URL format validation, and mutual-exclusivity guards.
- **Comprehensive test suite** — 354 total tests (29 modifier unit tests, 10 CLI integration tests, 12 utility tests) covering each operation, V2-only torrents, hybrid torrents, error paths, and end-to-end workflows.
- **Documentation** — `README.md` updated with full `modify` subcommand usage and examples for all flags.

## Testing
- [x] Tested locally
- [x] Unit tests added
- [x] Documentation updated

## Breaking Changes
None — purely additive (new subcommand, new utility functions, no existing behavior changed).

## Related Issues
Closes #19