### PR TITLE
feat: add YAML preset system and parallel batch torrent creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,17 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(cxxopts)
 
+# yaml-cpp (YAML parsing for presets and batch config)
+find_package(yaml-cpp QUIET)
+if(NOT yaml-cpp_FOUND)
+    FetchContent_Declare(
+        yaml-cpp
+        URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.9.0.tar.gz
+    )
+    set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(yaml-cpp)
+endif()
+
 # GoogleTest (testing framework)
 FetchContent_Declare(
     googletest
@@ -89,6 +100,23 @@ target_link_libraries(torrent_builder_core PUBLIC
 target_compile_options(torrent_builder_core PRIVATE ${LIBTORRENT_CFLAGS})
 target_link_options(torrent_builder_core PRIVATE ${LIBTORRENT_LDFLAGS})
 
+# ─── Config library (preset + batch, separate from core) ──────
+add_library(torrent_builder_config STATIC
+    src/preset.cpp
+    src/batch.cpp
+)
+
+target_include_directories(torrent_builder_config PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${LIBTORRENT_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
+)
+
+target_link_libraries(torrent_builder_config PUBLIC
+    torrent_builder_core
+    yaml-cpp::yaml-cpp
+)
+
 # ─── CLI executable ──────────────────────────────────────────
 add_executable(torrent_builder
     src/torrent_builder.cpp
@@ -100,6 +128,7 @@ target_include_directories(torrent_builder PRIVATE
 
 target_link_libraries(torrent_builder PRIVATE
     torrent_builder_core
+    torrent_builder_config
     cxxopts::cxxopts
 )
 
@@ -121,6 +150,7 @@ if(TEST_SOURCES)
     target_link_libraries(torrent_builder_tests PRIVATE
         GTest::gtest_main
         torrent_builder_core
+        torrent_builder_config
     )
 
     include(GoogleTest)

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -1,0 +1,209 @@
+---
+created: 2026-05-16
+branch: feat/preset-batch-mode
+type: feat
+issue: 27
+---
+
+## Objective
+
+Implement the preset system (#25) and batch mode (#27) together. Both features share the yaml-cpp dependency and batch mode depends on the preset system for the `preset:` field in batch jobs.
+
+## Preset System (#25)
+
+Add YAML-based preset configuration that saves per-tracker settings and applies them automatically. Users can reference presets by name via `--preset <name>`.
+
+### Preset YAML Format
+
+```yaml
+version: 1
+default:
+  private: true
+  exclude_patterns: ["*.nfo"]
+  piece_length: 0
+
+presets:
+  ptp:
+    source: "PTP"
+    trackers:
+      - "https://ptp.example/announce"
+    exclude_patterns: ["*.nfo", "*.txt"]
+    include_patterns: ["*.mkv", "*.mp4"]
+  public:
+    private: false
+    trackers:
+      - "udp://tracker.opentrackr.org:1337/announce"
+```
+
+### Preset File Search Order
+
+1. `./presets.yaml` (current working directory)
+2. `$XDG_CONFIG_HOME/torrent-builder/presets.yaml` (falls back to `~/.config/` when unset)
+3. `--preset-file <path>` (explicit override)
+
+### Merge Hierarchy
+
+CLI flags > preset values > `default:` section > TorrentConfig built-in defaults
+
+Uses an intermediate `ConfigValues` struct (all-optional fields) as the merge layer. CLI flags are captured via `result.count()` into `ConfigValues`, presets are parsed into `ConfigValues`, then merged before constructing `TorrentConfig`. This ensures correct "was this explicitly set?" tracking.
+
+## Batch Mode (#27)
+
+Add batch processing via a YAML config file that processes multiple torrent creation jobs, optionally in parallel.
+
+### Batch YAML Format
+
+```yaml
+version: 1
+workers: 2
+preset_file: "/path/to/presets.yaml"
+output_dir: "/path/to/output"
+
+jobs:
+  - path: "/path/to/movie"
+    output: "Movie.2026.torrent"
+    trackers: ["https://tracker.example/announce"]
+    private: true
+    source: "SRC"
+    exclude_patterns: ["*.nfo"]
+
+  - path: "/path/to/show"
+    output: "Show.S01.torrent"
+    preset: ptp
+
+  - path: "/path/to/album"
+    preset: public
+```
+
+### Batch Features
+
+- Parallel processing with configurable worker count (default: 1)
+- Summary report: success/failure per job with elapsed time
+- Each job supports all create flags + preset references
+- Failed jobs logged but don't block remaining queue
+- Batch mode suppresses interactive prompts (always overwrites)
+- Auto-output generation when `output` field is omitted
+
+## Implementation Plan
+
+### Phase 1: Add yaml-cpp Dependency
+
+- [ ] Modify `CMakeLists.txt` to add `yaml-cpp` 0.8.0 (find_package fallback, then FetchContent)
+- [ ] Link `yaml-cpp::yaml-cpp` to a new `torrent_builder_config` static library
+- [ ] Verify build succeeds on all platforms
+
+### Phase 2: Preset System
+
+- [ ] Create `include/preset.hpp` with `ConfigValues` struct (all-optional, used as intermediate merge layer) and `PresetLoader` class
+- [ ] Create `src/preset.cpp` with YAML parsing, XDG-aware file search, preset resolution logic
+- [ ] Add `src/preset.cpp` to `torrent_builder_config` library in CMakeLists.txt
+- [ ] Modify `src/torrent_builder.cpp`: add `--preset` and `--preset-file` flags to create subcommand
+- [ ] Refactor `get_commandline_config()` to produce `ConfigValues` first, merge with preset, then construct `TorrentConfig`
+- [ ] Create `tests/test_preset.cpp` with unit tests for parsing, merge, and precedence
+
+### Phase 3: Batch Mode
+
+- [ ] Create `include/batch.hpp` with `BatchJob`, `BatchConfig`, `BatchResult` structs and `BatchProcessor` class
+- [ ] Create `src/batch.cpp` with batch YAML parsing, parallel execution (atomic counter), summary report
+- [ ] Add `src/batch.cpp` to `torrent_builder_config` library in CMakeLists.txt
+- [ ] Modify `src/torrent_builder.cpp`: add `batch` subcommand handler (`handle_batch_command()`)
+- [ ] Implement parallel execution with `std::jthread` + `std::atomic<int>` counter (fork-join pattern)
+- [ ] Implement summary report printing
+- [ ] Create `tests/test_batch.cpp` with unit tests
+
+### Phase 4: CLI Integration Tests
+
+- [ ] Add batch subcommand tests to `tests/test_cli.cpp` (valid batch, invalid YAML, missing file)
+- [ ] Add preset flag tests to `tests/test_cli.cpp` (--preset, --preset-file, unknown preset)
+
+## Key Design Decisions
+
+### ConfigValues Struct (Intermediate Merge Layer)
+
+All-optional fields mirroring TorrentConfig. Serves as the single intermediate for both CLI flag capture (via `result.count()`) and YAML preset data. Enables correct 3-way merge: `default → named_preset → cli_or_job`.
+
+```cpp
+struct ConfigValues {
+    std::optional<std::string> path;
+    std::optional<std::string> output;
+    std::optional<std::vector<std::string>> trackers;
+    std::optional<std::vector<std::string>> web_seeds;
+    std::optional<bool> is_private;
+    std::optional<std::string> source;
+    std::optional<int> piece_size;             // KB, nullopt = auto
+    std::optional<std::string> comment;
+    std::optional<std::string> creator;
+    std::optional<std::string> name;
+    std::optional<bool> creation_date;
+    std::optional<int> torrent_version;        // 1/2/3
+    std::optional<bool> entropy;
+    std::optional<std::vector<std::string>> exclude_patterns;
+    std::optional<std::vector<std::string>> include_patterns;
+};
+```
+
+### Batch Parallelism
+
+- Fork-join pattern using `std::jthread` + `std::atomic<int>` counter (no queue/mutex/cv needed)
+- Each worker atomically increments counter to claim next job index
+- Each job gets its own `TorrentCreator` instance (no shared mutable state)
+- Results vector pre-allocated by job index for ordered output
+
+### Batch Output Handling
+
+- When `output` is omitted: use `utils::generate_auto_output_path()` with job's trackers
+- Batch-level `output_dir` applies as default directory for auto-generated outputs
+- Skip overwrite prompts in batch mode (always overwrite)
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `CMakeLists.txt` | Modify — yaml-cpp (find_package + FetchContent), new `torrent_builder_config` library |
+| `include/preset.hpp` | New — ConfigValues struct, PresetLoader class |
+| `src/preset.cpp` | New — YAML parsing, XDG-aware file search, preset resolution |
+| `include/batch.hpp` | New — BatchJob, BatchConfig, BatchResult, BatchProcessor |
+| `src/batch.cpp` | New — batch YAML parsing, parallel execution, summary report |
+| `src/torrent_builder.cpp` | Modify — batch subcommand, --preset/--preset-file flags |
+| `tests/test_preset.cpp` | New — preset unit tests |
+| `tests/test_batch.cpp` | New — batch unit tests |
+| `tests/test_cli.cpp` | Modify — add batch/preset CLI integration tests |
+
+## Acceptance Criteria
+
+### Preset System (#25)
+
+- [ ] Parse YAML preset files with hierarchical merge (default → preset → CLI)
+- [ ] Search for presets in standard locations (cwd, XDG config dir, custom path)
+- [ ] `--preset <name>` flag loads and applies a named preset
+- [ ] CLI flags override preset values
+- [ ] Unknown preset name produces clear error
+- [ ] Unit tests for YAML parsing and merge logic
+- [ ] Integration with `--source`, `--exclude`/`--include`, and tracker flags
+
+### Batch Mode (#27)
+
+- [ ] `batch` subcommand reads YAML job list
+- [ ] Parallel processing with configurable worker count
+- [ ] Each job supports all create flags
+- [ ] Jobs can reference presets by name
+- [ ] Summary report with per-job status
+- [ ] Failed jobs logged but don't block remaining queue
+- [ ] Unit tests for job parsing and parallel execution
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| yaml-cpp FetchContent build fails on some platforms | Test on all CI platforms (Linux/Windows/macOS). Pin stable version 0.8.0. |
+| Thread safety in parallel batch mode | Each job gets its own TorrentCreator instance. No shared mutable state between workers. Results vector pre-allocated by job index. |
+| Memory pressure: N parallel jobs each running multi-threaded hashing | Default worker count is 1. Document tuning guidance. Users control via config. |
+| Preset + CLI flag merge complexity | Track "was specified?" per field explicitly. Unit test merge logic thoroughly. |
+| Batch mode interactive prompts | Auto-set QUIET verbosity in batch mode. Skip overwrite prompts. |
+
+## Validation Strategy
+
+1. Build check: `cmake --build build` compiles clean
+2. Unit tests: `ctest --output-on-failure` — all existing + new tests pass
+3. Manual smoke test: create presets.yaml + batch.yaml with 2-3 small test jobs
+4. CI: existing GitHub Actions covers Linux/Windows/macOS

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The **Torrent Builder** is a command-line tool for creating torrent files, offer
 - Auto-naming: output filename generated from tracker domain and content name
 - Collision-safe naming: automatically resolves filename conflicts with `(1)`, `(2)`, etc.
 - Filename truncation with UTF-8 boundary safety (255-byte filesystem limit)
+- YAML-based preset system for per-tracker configuration
+- Batch mode: create multiple torrents in parallel from a YAML config
 - Configurable output directory (auto-created if needed) and tracker index for filename prefix
 
 ## Prerequisites
@@ -98,6 +100,14 @@ Edit metadata of an existing .torrent file in-place without re-hashing file cont
 
 > **Note:** `--output` is optional. When omitted, the output filename is auto-generated from the tracker domain and content name (e.g., `tracker.example.com_myfile.torrent`).
 
+### Batch Mode
+
+```bash
+./torrent_builder batch batch.yaml [--workers N]
+```
+
+Process multiple torrent creation jobs from a YAML config file in parallel. See the [Batch Mode](#batch-mode-1) section below for details.
+
 ## Options
 
 ```
@@ -126,6 +136,8 @@ Edit metadata of an existing .torrent file in-place without re-hashing file cont
        --skip-prefix          Omit tracker domain from auto-generated output filename
       --output-dir DIR       Directory for auto-generated output filename (created if needed)
       --tracker-index N      Index of tracker to use for filename prefix (0-based, default: 0)
+      --preset NAME          Apply named preset from presets.yaml
+      --preset-file FILE     Load presets from specified file (default: searches ./presets.yaml, $XDG_CONFIG_HOME/torrent-builder/presets.yaml, ~/.config/torrent-builder/presets.yaml)
 ```
 
 > **Note:** `--verbose`, `--quiet`, and `--json` are ignored in interactive mode. In CLI mode, `--verbose` and `--quiet` are mutually exclusive, as are `--verbose` and `--json`. The `--json` flag implies `--quiet` and auto-declines any overwrite prompts.
@@ -350,6 +362,79 @@ Modify torrent metadata:
 ./torrent_builder modify file.torrent --output modified.torrent --entropy
 # Write to a new file instead of modifying in-place
 ```
+
+### Preset System
+
+Presets save per-tracker settings in a YAML file. Use `--preset <name>` to apply a preset when creating a torrent.
+
+**Preset file format** (`presets.yaml`):
+```yaml
+version: 1
+default:
+  private: true
+  exclude_patterns: ["*.nfo", "*.txt"]
+
+presets:
+  ptp:
+    source: "PTP"
+    trackers:
+      - "https://ptp.example/announce"
+    exclude_patterns: ["*.nfo", "*.txt", "*.sfv"]
+
+  public:
+    private: false
+    trackers:
+      - "udp://tracker.example/announce"
+```
+
+**Preset file resolution**: `--preset-file` (if given, used directly). Otherwise, search order: `./presets.yaml` → `$XDG_CONFIG_HOME/torrent-builder/presets.yaml` → `~/.config/torrent-builder/presets.yaml`.
+
+**Merge hierarchy**: CLI flags > preset values > `default:` section > built-in defaults.
+
+**Usage:**
+```bash
+# Apply a preset
+./torrent_builder --preset ptp --path /data/file -o file.torrent
+
+# Specify a custom preset file
+./torrent_builder --preset ptp --preset-file /config/presets.yaml --path /data/file -o file.torrent
+
+# Preset values are overridden by CLI flags
+./torrent_builder --preset ptp --path /data/file -o file.torrent --comment "override"
+```
+
+### Batch Mode
+
+Create multiple torrents in parallel from a YAML config file.
+
+**Batch file format** (`batch.yaml`):
+```yaml
+version: 1
+workers: 2
+preset_file: presets.yaml
+output_dir: /torrents/output
+
+jobs:
+  - path: /data/movie1.mkv
+    preset: ptp
+  - path: /data/movie2.mkv
+    output: custom_output.torrent
+    trackers:
+      - "https://tracker.example/announce"
+```
+
+> **Note:** Output paths automatically receive a `.torrent` extension if not already present. `workers: 0` in the YAML config throws an error; `--workers 0` on the CLI is ignored with a warning.
+
+**Usage:**
+```bash
+# Run a batch job
+./torrent_builder batch batch.yaml
+
+# Override worker count
+./torrent_builder batch batch.yaml --workers 4
+```
+
+Each job can optionally reference a preset by name. Jobs run in parallel with `--workers` threads (default: 1). A summary showing success/failure per job is printed at the end.
 
 ## Troubleshooting
 

--- a/REMAINING_GAPS.md
+++ b/REMAINING_GAPS.md
@@ -1,0 +1,85 @@
+# Remaining Gaps — Round 6 Code Review
+
+## Minor (Test Coverage)
+
+- [ ] PresetLoader::load() file size limit untested (batch equivalent tested via ParseFileTooLargeThrows)
+  - src/preset.cpp:127-130 (1MB file_size check before LoadFile)
+  - Add PresetTest.LoadFileTooLargeThrows test
+
+- [ ] CWD preset search success path untested
+  - src/preset.cpp:find_preset_file() checks ./presets.yaml before XDG/HOME
+  - XDG path tested (FindPresetFileXDGConfigHome), CWD path is not
+  - Add test that creates ./presets.yaml and verifies find_preset_file() returns it
+
+- [ ] Worker capping logic untested
+  - src/batch.cpp:293-297 (min(config.workers, jobs.size(), hardware_concurrency * 2))
+  - No test deliberately triggers the cap (e.g. workers > jobs or workers > hw_concurrency * 2)
+  - Add test with workers: 100 and verify actual_workers is capped
+
+- [ ] 9 of 13 CLI preset fallback fields without direct CLI-level regression test
+  - src/torrent_builder.cpp:get_commandline_config() — name, web_seeds, piece_size, creator, creation_date, entropy, torrent_version, exclude_patterns, include_patterns
+  - Unit tests cover parsing and merge; CLI integration tests cover comment, source, private, trackers
+  - Add CLI tests verifying these fields propagate from preset to created torrent
+
+- [ ] Batch CLI exit code with job failure unverified
+  - src/torrent_builder.cpp:handle_batch_command returns 1 if any job fails
+  - No CLI test creates a batch with a failing job and checks exit code != 0
+  - Add test with invalid path in batch job, verify exit code 1
+
+- [ ] FindPresetFileNoFileThrows lacks env isolation
+  - tests/test_preset.cpp:FindPresetFileNoFileThrows may pass unexpectedly if ~/.config/torrent-builder/presets.yaml exists
+  - Wrap with XDG_CONFIG_HOME save/restore like FindPresetFileXDGConfigHome
+
+## Minor (Plan Deviation)
+
+- [ ] yaml-cpp version mismatch: planned 0.8.0, implemented find_package(0.6.0) + FetchContent(0.9.0)
+  - CMakeLists.txt — compatible, 0.9.0 is newer stable release
+  - Low risk: only basic YAML features used (scalars, sequences, maps)
+
+## Minor (Observability)
+
+- [ ] handle_batch_command missing specialized catch blocks for filesystem_error and YAML::Exception
+  - src/torrent_builder.cpp:1108-1120 — only catches runtime_error and std::exception
+  - Main handler has dedicated catch blocks per type; batch handler lumps them together
+  - Not a correctness issue (filesystem_error and YAML::Exception both inherit runtime_error)
+
+## Previously Resolved (Rounds 1-5)
+
+- [x] optional<bool> merge bug — FIXED with .has_value() (preset.cpp)
+- [x] ANSI escape injection — FIXED with sanitize_for_terminal() (batch.cpp)
+- [x] Batch output .torrent extension — FIXED (batch.cpp)
+- [x] --workers 0 warning — FIXED with print_error + log_message (torrent_builder.cpp)
+- [x] Batch wall-clock time — FIXED (torrent_builder.cpp)
+- [x] fork-join terminology — FIXED to worker-pool (batch.hpp)
+- [x] Data race on results vector — FIXED with explicit joins (batch.cpp)
+- [x] Logger thread safety — FIXED with static mutex + localtime_r (logger.cpp, logger.hpp)
+- [x] YAML file size limit — FIXED with 1MB cap (preset.cpp, batch.cpp)
+- [x] Case-insensitive .torrent extension — FIXED with utils::to_lower (batch.cpp)
+- [x] Troubleshooting heading missing — FIXED (README.md)
+- [x] .torrent auto-append undocumented — FIXED (README.md)
+- [x] Batch subcommand missing from usage — FIXED (README.md)
+- [x] workers: 0 behavior undocumented — FIXED (README.md)
+- [x] --preset-file in batch CLI example (nonexistent flag) — FIXED (README.md)
+- [x] Job started log entry — FIXED (batch.cpp)
+- [x] Batch failure count at ERR level — FIXED (batch.cpp)
+- [x] log_mutex removed from batch.cpp — FIXED (logger now thread-safe)
+- [x] .torrent extension tests — FIXED (3 tests in test_batch.cpp)
+- [x] --workers 0 CLI test — FIXED (WorkersZeroShowsWarning in test_cli.cpp)
+- [x] YAML file size test — FIXED (ParseFileTooLargeThrows in test_batch.cpp)
+- [x] optional<bool> merge test — FIXED (MergeExplicitFalseOverridesTrue in test_preset.cpp)
+- [x] Preset tracker CLI tests — FIXED (PresetCLI.* in test_cli.cpp)
+- [x] Batch unknown preset test — FIXED (RunWithUnknownPresetFails)
+- [x] CLI --workers override test — FIXED (WorkersOverride)
+- [x] Missing preset file warning test — FIXED (RunWithoutPresetFileContinues)
+- [x] Invalid preset piece_size test — FIXED (RunWithInvalidPresetPieceSizeFails)
+- [x] TorrentCreator pass-by-value + move — FIXED
+- [x] Workers upper bound cap — FIXED (hardware_concurrency * 2)
+- [x] URL validation in preset/batch — FIXED
+- [x] Silent preset load failure — FIXED with WARNING log
+- [x] Missing CLI integration tests — ADDED
+- [x] Missing Doxygen comments — ADDED
+- [x] parse_yaml_config() forward declaration — MOVED to preset.hpp
+- [x] Unnecessary results_mutex — REMOVED
+- [x] Silent create_directories error — FIXED with ec check + throw
+- [x] Missing batch start log — ADDED
+- [x] Missing per-job success log — ADDED

--- a/include/batch.hpp
+++ b/include/batch.hpp
@@ -1,0 +1,70 @@
+#ifndef BATCH_HPP
+#define BATCH_HPP
+
+#include "preset.hpp"
+#include "torrent_creator.hpp"
+#include <string>
+#include <vector>
+#include <optional>
+#include <filesystem>
+#include <chrono>
+
+namespace fs = std::filesystem;
+
+/** @brief A single job within a batch configuration. */
+struct BatchJob {
+    std::string path;                      ///< Input file or directory
+    std::optional<std::string> output;     ///< Output .torrent path (auto-generated if empty)
+    std::optional<std::string> preset;     ///< Preset name to apply
+    ConfigValues values;                   ///< Per-job config overrides
+};
+
+/** @brief Parsed batch configuration from a YAML file. */
+struct BatchConfig {
+    int workers = 1;                       ///< Number of parallel workers (default: 1)
+    std::optional<fs::path> preset_file;   ///< Shared preset file for all jobs
+    std::optional<fs::path> output_dir;    ///< Default output directory
+    std::vector<BatchJob> jobs;            ///< Ordered list of jobs to execute
+};
+
+/** @brief Result of executing a single batch job. */
+struct BatchResult {
+    int job_index;                         ///< Index into the jobs vector
+    std::string job_name;                  ///< Display name (output path or input path)
+    bool success;                          ///< Whether the torrent was created successfully
+    std::string error_message;             ///< Error details if success is false
+    double elapsed_seconds;                ///< Wall-clock time for this job
+};
+
+/** @brief Parses batch YAML files and executes jobs in parallel.
+ *
+ * Uses a worker-pool pattern with std::jthread. Each worker pulls the next
+ * available job index via an atomic counter, executes it, and stores the result.
+ *
+ * Thread oversubscription note: each worker internally spawns hashing threads
+ * via libtorrent. Total threads ≈ workers × hashing_threads. Consider capping
+ * workers to available cores for CPU-bound workloads.
+ */
+class BatchProcessor {
+public:
+    /** @brief Construct a processor with the given batch configuration. */
+    explicit BatchProcessor(BatchConfig config);
+
+    /** @brief Parse a batch YAML file into a BatchConfig.
+     * @throws std::runtime_error on missing file, bad version, or parse errors.
+     */
+    static BatchConfig parse(const fs::path& yaml_path);
+
+    /** @brief Execute all jobs and return results in order. */
+    std::vector<BatchResult> run();
+
+    /** @brief Print a human-readable summary to stdout. */
+    static void print_summary(const std::vector<BatchResult>& results);
+
+private:
+    BatchConfig config_;
+
+    BatchResult execute_job(int job_index, const PresetLoader& presets);
+};
+
+#endif

--- a/include/batch.hpp
+++ b/include/batch.hpp
@@ -38,7 +38,7 @@ struct BatchResult {
 
 /** @brief Parses batch YAML files and executes jobs in parallel.
  *
- * Uses a worker-pool pattern with std::jthread. Each worker pulls the next
+ * Uses a worker-pool pattern with std::thread. Each worker pulls the next
  * available job index via an atomic counter, executes it, and stores the result.
  *
  * Thread oversubscription note: each worker internally spawns hashing threads

--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -25,7 +25,7 @@ enum class LogLevel {
  * @param message  Human-readable description of the event.
  * @param level    Severity level (defaults to INFO).
  *
- * @note Not thread-safe. Callers in multi-threaded contexts must synchronize externally.
+ * @note Thread-safe. Uses an internal mutex for concurrent access.
  */
 void log_message(const std::string& message, LogLevel level = LogLevel::INFO);
 

--- a/include/preset.hpp
+++ b/include/preset.hpp
@@ -1,0 +1,86 @@
+#ifndef PRESET_HPP
+#define PRESET_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <filesystem>
+#include <unordered_map>
+
+namespace YAML { class Node; }
+
+namespace fs = std::filesystem;
+
+/** @brief Intermediate config layer with all-optional fields for merge tracking.
+ *
+ * Used as the glue between YAML presets, batch config, and CLI flags.
+ * Merge hierarchy: CLI flags > preset values > default section > TorrentConfig built-in defaults.
+ */
+struct ConfigValues {
+    std::optional<std::string> path;                ///< Input file or directory path
+    std::optional<std::string> output;              ///< Output .torrent file path
+    std::optional<std::vector<std::string>> trackers;///< Tracker announce URLs
+    std::optional<std::vector<std::string>> web_seeds;///< Web seed URLs
+    std::optional<bool> is_private;                  ///< Whether torrent is private
+    std::optional<std::string> source;              ///< Source field embedding
+    std::optional<int> piece_size;                  ///< Piece size in KB (e.g. 4096 = 4MB)
+    std::optional<std::string> comment;             ///< Torrent comment
+    std::optional<std::string> creator;             ///< Created-by field
+    std::optional<std::string> name;                ///< Torrent name override
+    std::optional<bool> creation_date;              ///< Whether to embed creation date
+    std::optional<int> torrent_version;             ///< 1=V1, 2=V2, 3=Hybrid
+    std::optional<bool> entropy;                    ///< Whether to include entropy data
+    std::optional<std::vector<std::string>> exclude_patterns;///< Glob patterns to exclude
+    std::optional<std::vector<std::string>> include_patterns;///< Glob patterns to include
+};
+
+/** @brief Merge two ConfigValues: overlay fields win over base. */
+ConfigValues merge_config_values(const ConfigValues& base, const ConfigValues& overlay);
+
+/** @brief Parse torrent config fields from a YAML node.
+ *
+ * Extracts all optional fields (trackers, web_seeds, private, source, piece_size,
+ * comment, creator, name, creation_date, torrent_version, entropy, exclude/include_patterns)
+ * from the given YAML node. Validates tracker and web seed URLs.
+ *
+ * @param node YAML node to parse (a preset entry, batch job, or default section).
+ * @return ConfigValues with any recognized fields populated.
+ * @throws std::runtime_error on invalid tracker/web seed URLs.
+ */
+ConfigValues parse_yaml_config(const YAML::Node& node);
+
+/** @brief Discovers and loads YAML preset files for torrent configuration.
+ *
+ * Search order for preset files:
+ *   1. Explicit path (if provided)
+ *   2. ./presets.yaml (current working directory)
+ *   3. $XDG_CONFIG_HOME/torrent-builder/presets.yaml
+ *   4. ~/.config/torrent-builder/presets.yaml
+ */
+class PresetLoader {
+public:
+    /** @brief Locate a preset file on disk.
+     * @param explicit_path If provided, use this path directly.
+     * @throws std::runtime_error if no file is found.
+     */
+    static fs::path find_preset_file(const std::optional<fs::path>& explicit_path);
+
+    /** @brief Load and parse a preset YAML file.
+     * @throws std::runtime_error on unsupported version or parse errors.
+     */
+    void load(const fs::path& path);
+
+    /** @brief Resolve a named preset merged with defaults.
+     * @throws std::runtime_error if the preset name does not exist.
+     */
+    ConfigValues resolve(const std::string& name) const;
+
+    /** @brief Check whether a named preset exists. */
+    bool has_preset(const std::string& name) const;
+
+private:
+    ConfigValues defaults_;
+    std::unordered_map<std::string, ConfigValues> presets_;
+};
+
+#endif

--- a/include/torrent_creator.hpp
+++ b/include/torrent_creator.hpp
@@ -100,7 +100,7 @@ public:
      * @brief Construct a torrent creator with the given configuration.
      * @param config Fully populated TorrentConfig.
      */
-    explicit TorrentCreator(const TorrentConfig& config);
+    explicit TorrentCreator(TorrentConfig config);
 
     /**
      * @brief Create and save a .torrent file according to the configuration.

--- a/include/torrent_creator.hpp
+++ b/include/torrent_creator.hpp
@@ -49,6 +49,7 @@ struct TorrentConfig {
     bool entropy;                                 // Randomize info hash per invocation
     std::vector<std::regex> exclude_regex;        // Pre-compiled exclude patterns
     std::vector<std::regex> include_regex;        // Pre-compiled include patterns (overrides exclude)
+    bool silent;                                   // Suppress progress output (batch mode)
 
     /**
      * @brief Construct a torrent configuration with all creation parameters.
@@ -78,13 +79,15 @@ struct TorrentConfig {
                  std::optional<std::string> source = std::nullopt,
                  bool entropy = false,
                  std::vector<std::regex> exclude_re = {},
-                 std::vector<std::regex> include_re = {})
+                 std::vector<std::regex> include_re = {},
+                 bool silent = false)
         : path(p), output(o), trackers(t), version(v),
           comment(c), is_private(priv), web_seeds(ws), piece_size(ps),
           creator(creator), name(name_val), include_creation_date(include_creation_date),
           source(source), entropy(entropy),
           exclude_regex(std::move(exclude_re)),
-          include_regex(std::move(include_re))
+          include_regex(std::move(include_re)),
+          silent(silent)
     {
         // Validate that the provided path exists
         std::error_code ec;

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -243,6 +243,7 @@ BatchResult BatchProcessor::execute_job(int job_index, const PresetLoader& prese
         }
 
         TorrentConfig tc = build_torrent_config(resolved, output_dir);
+        tc.silent = true;
         TorrentCreator creator(std::move(tc));
         creator.create_torrent();
 
@@ -297,7 +298,7 @@ std::vector<BatchResult> BatchProcessor::run()
     }
     log_message("Starting batch execution: " + std::to_string(config_.jobs.size())
         + " jobs, " + std::to_string(actual_workers) + " workers", LogLevel::INFO);
-    std::vector<std::jthread> threads;
+    std::vector<std::thread> threads;
     threads.reserve(actual_workers);
 
     for (int i = 0; i < actual_workers; ++i) {

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -1,0 +1,347 @@
+#include "batch.hpp"
+#include "preset.hpp"
+#include "logger.hpp"
+#include "output.hpp"
+#include "utils.hpp"
+#include "constants.hpp"
+#include <yaml-cpp/yaml.h>
+#include <thread>
+#include <atomic>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cmath>
+
+namespace
+{
+
+std::string sanitize_for_terminal(const std::string& s)
+{
+    std::string result;
+    result.reserve(s.size());
+    for (unsigned char c : s) {
+        if (c >= 0x20 && c != 0x7f) {
+            result += static_cast<char>(c);
+        }
+    }
+    return result;
+}
+
+std::optional<int> validate_piece_size(int ps_kb)
+{
+    static const std::vector<int> allowed(AllowedPieceSizes::values.begin(),
+                                          AllowedPieceSizes::values.end());
+    if (ps_kb == 0) return std::nullopt;
+    if (std::ranges::contains(allowed, ps_kb)) {
+        return ps_kb * 1024;
+    }
+    throw std::runtime_error("Invalid piece size: " + std::to_string(ps_kb) + " KB");
+}
+
+TorrentVersion resolve_version(int v)
+{
+    switch (v) {
+        case 1: return TorrentVersion::V1;
+        case 2: return TorrentVersion::V2;
+        default: return TorrentVersion::HYBRID;
+    }
+}
+
+std::vector<std::regex> compile_patterns(const std::optional<std::vector<std::string>>& patterns)
+{
+    std::vector<std::regex> compiled;
+    if (patterns) {
+        for (const auto& p : *patterns) {
+            try {
+                compiled.push_back(utils::glob_to_regex(p));
+            } catch (const std::regex_error&) {
+                throw std::runtime_error("Invalid pattern: " + p);
+            }
+        }
+    }
+    return compiled;
+}
+
+TorrentConfig build_torrent_config(const ConfigValues& cv, const fs::path& default_output_dir)
+{
+    fs::path input_path(cv.path.value());
+    if (!fs::exists(input_path)) {
+        throw std::runtime_error("Path does not exist: " + input_path.string());
+    }
+
+    fs::path output;
+    if (cv.output) {
+        output = *cv.output;
+    } else {
+        auto trackers = cv.trackers.value_or(std::vector<std::string>{});
+        fs::path out_dir = default_output_dir.empty() ? fs::current_path() : default_output_dir;
+        if (!out_dir.empty() && !fs::exists(out_dir)) {
+            std::error_code ec;
+            fs::create_directories(out_dir, ec);
+            if (ec) {
+                throw std::runtime_error("Failed to create output directory: " + out_dir.string() + " (" + ec.message() + ")");
+            }
+        }
+        output = utils::generate_auto_output_path(input_path, trackers, false, 0, out_dir);
+    }
+
+    TorrentVersion version = TorrentVersion::HYBRID;
+    if (cv.torrent_version) {
+        version = resolve_version(*cv.torrent_version);
+    }
+
+    std::optional<int> piece_size_bytes;
+    if (cv.piece_size && *cv.piece_size > 0) {
+        piece_size_bytes = validate_piece_size(*cv.piece_size);
+    }
+
+    std::optional<std::string> creator;
+    if (cv.creator) {
+        creator = *cv.creator;
+    }
+
+    return TorrentConfig(
+        input_path,
+        output,
+        cv.trackers.value_or(std::vector<std::string>{}),
+        version,
+        cv.comment,
+        cv.is_private.value_or(false),
+        cv.web_seeds.value_or(std::vector<std::string>{}),
+        piece_size_bytes,
+        creator,
+        cv.name,
+        cv.creation_date.value_or(false),
+        cv.source,
+        cv.entropy.value_or(false),
+        compile_patterns(cv.exclude_patterns),
+        compile_patterns(cv.include_patterns)
+    );
+}
+
+}
+
+ConfigValues parse_yaml_config(const YAML::Node& node);
+
+namespace
+{
+
+ConfigValues parse_job_node(const YAML::Node& node)
+{
+    ConfigValues cv = parse_yaml_config(node);
+
+    if (node["path"]) cv.path = node["path"].as<std::string>();
+    if (node["output"]) cv.output = node["output"].as<std::string>();
+
+    return cv;
+}
+
+}
+
+BatchProcessor::BatchProcessor(BatchConfig config)
+    : config_(std::move(config))
+{
+}
+
+BatchConfig BatchProcessor::parse(const fs::path& yaml_path)
+{
+    if (!fs::exists(yaml_path)) {
+        throw std::runtime_error("Batch file not found: " + yaml_path.string());
+    }
+
+    static constexpr std::uintmax_t max_yaml_size = 1 * 1024 * 1024;
+    if (fs::file_size(yaml_path) > max_yaml_size) {
+        throw std::runtime_error("Batch file too large (max 1 MB): " + yaml_path.string());
+    }
+
+    YAML::Node root = YAML::LoadFile(yaml_path.string());
+
+    if (!root["version"] || root["version"].as<int>() != 1) {
+        throw std::runtime_error("Unsupported batch file version (expected: 1)");
+    }
+
+    BatchConfig config;
+
+    if (root["workers"]) {
+        config.workers = root["workers"].as<int>();
+        if (config.workers < 1) {
+            throw std::runtime_error("Workers must be >= 1");
+        }
+    }
+
+    if (root["preset_file"]) {
+        config.preset_file = root["preset_file"].as<std::string>();
+    }
+
+    if (root["output_dir"]) {
+        config.output_dir = root["output_dir"].as<std::string>();
+    }
+
+    if (!root["jobs"] || !root["jobs"].IsSequence()) {
+        throw std::runtime_error("Batch file must contain a 'jobs' list");
+    }
+
+    for (const auto& job_node : root["jobs"]) {
+        BatchJob job;
+        job.values = parse_job_node(job_node);
+
+        if (!job.values.path) {
+            throw std::runtime_error("Each batch job must have a 'path' field");
+        }
+
+        if (job_node["output"]) {
+            std::string out = job_node["output"].as<std::string>();
+            if (out.size() < 8 || utils::to_lower(out.substr(out.size() - 8)) != ".torrent") {
+                out += ".torrent";
+            }
+            job.output = std::move(out);
+        }
+
+        if (job_node["preset"]) {
+            job.preset = job_node["preset"].as<std::string>();
+        }
+
+        job.path = *job.values.path;
+        config.jobs.push_back(std::move(job));
+    }
+
+    log_message("Parsed batch config: " + std::to_string(config.jobs.size())
+        + " jobs, " + std::to_string(config.workers) + " workers", LogLevel::INFO);
+
+    return config;
+}
+
+BatchResult BatchProcessor::execute_job(int job_index, const PresetLoader& presets)
+{
+    const BatchJob& job = config_.jobs[job_index];
+    BatchResult result;
+    result.job_index = job_index;
+    result.job_name = job.output.value_or(job.path);
+    result.success = false;
+
+    auto start = std::chrono::steady_clock::now();
+
+    try {
+        ConfigValues resolved;
+
+        if (job.preset) {
+            resolved = presets.resolve(*job.preset);
+        }
+
+        resolved = merge_config_values(resolved, job.values);
+
+        if (!resolved.path) {
+            resolved.path = job.path;
+        }
+        if (!resolved.output && job.output) {
+            resolved.output = *job.output;
+        }
+
+        fs::path output_dir;
+        if (config_.output_dir) {
+            output_dir = *config_.output_dir;
+        }
+
+        TorrentConfig tc = build_torrent_config(resolved, output_dir);
+        TorrentCreator creator(std::move(tc));
+        creator.create_torrent();
+
+        result.success = true;
+    } catch (const std::exception& e) {
+        result.error_message = e.what();
+    }
+
+    auto end = std::chrono::steady_clock::now();
+    result.elapsed_seconds = std::chrono::duration<double>(end - start).count();
+
+    return result;
+}
+
+std::vector<BatchResult> BatchProcessor::run()
+{
+    PresetLoader presets;
+    try {
+        auto preset_path = PresetLoader::find_preset_file(config_.preset_file);
+        presets.load(preset_path);
+    } catch (const std::runtime_error& e) {
+        log_message("Preset file not available: " + std::string(e.what()), LogLevel::WARNING);
+    }
+
+    std::vector<BatchResult> results(config_.jobs.size());
+    std::atomic<int> next_job{0};
+
+    auto worker = [&]() {
+        while (true) {
+            int idx = next_job.fetch_add(1);
+            if (idx >= static_cast<int>(config_.jobs.size())) break;
+
+            log_message("Job " + std::to_string(idx + 1) + " started: "
+                + sanitize_for_terminal(config_.jobs[idx].path), LogLevel::INFO);
+
+            results[idx] = execute_job(idx, presets);
+
+            if (results[idx].success) {
+                log_message("Job " + std::to_string(idx + 1) + " completed ("
+                    + std::to_string(results[idx].elapsed_seconds) + "s)", LogLevel::INFO);
+            } else {
+                log_message("Job " + std::to_string(idx + 1) + " failed: "
+                    + sanitize_for_terminal(results[idx].error_message), LogLevel::ERR);
+            }
+        }
+    };
+
+    int actual_workers = std::min(config_.workers, static_cast<int>(config_.jobs.size()));
+    const int max_workers = static_cast<int>(std::thread::hardware_concurrency()) * 2;
+    if (actual_workers > max_workers && max_workers > 0) {
+        actual_workers = max_workers;
+    }
+    log_message("Starting batch execution: " + std::to_string(config_.jobs.size())
+        + " jobs, " + std::to_string(actual_workers) + " workers", LogLevel::INFO);
+    std::vector<std::jthread> threads;
+    threads.reserve(actual_workers);
+
+    for (int i = 0; i < actual_workers; ++i) {
+        threads.emplace_back(worker);
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    return results;
+}
+
+void BatchProcessor::print_summary(const std::vector<BatchResult>& results)
+{
+    int succeeded = 0;
+    int failed = 0;
+
+    for (const auto& r : results) {
+        if (r.success) ++succeeded;
+        else ++failed;
+    }
+
+    std::ostringstream oss;
+    oss << "\nBatch Summary (" << results.size() << " jobs):\n";
+
+    for (const auto& r : results) {
+        std::ostringstream time_str;
+        time_str << std::fixed << std::setprecision(1) << r.elapsed_seconds << "s";
+
+        if (r.success) {
+            oss << "  \u2713 " << sanitize_for_terminal(r.job_name);
+            oss << "  completed (" << time_str.str() << ")\n";
+        } else {
+            oss << "  \u2717 " << sanitize_for_terminal(r.job_name);
+            oss << "  FAILED: " << sanitize_for_terminal(r.error_message) << "\n";
+        }
+    }
+
+    oss << "\n  Succeeded: " << succeeded << "    Failed: " << failed << "\n";
+
+    std::cout << oss.str();
+    if (failed > 0) {
+        log_message("Batch completed with " + std::to_string(failed) + " failed job(s)", LogLevel::ERR);
+    }
+    log_message(oss.str(), LogLevel::INFO);
+}

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -6,8 +6,7 @@
  * The file is opened and closed on each call to ensure entries are flushed
  * even if the process terminates unexpectedly (e.g., std::exit).
  *
- * Thread safety: Not thread-safe. External synchronization is required
- * when called from concurrent threads.
+ * Thread safety: Thread-safe. Uses an internal mutex and localtime_r.
  */
 
 #include "logger.hpp"
@@ -15,12 +14,13 @@
 #include <chrono>
 #include <iomanip>
 #include <ctime>
+#include <mutex>
 
 void log_message(const std::string& message, LogLevel level) {
+    static std::mutex log_mutex;
+
     auto now = std::chrono::system_clock::now();
     auto now_time_t = std::chrono::system_clock::to_time_t(now);
-
-    std::ofstream logfile("torrent_builder.log", std::ios_base::app);
 
     std::string level_str;
     switch(level) {
@@ -29,6 +29,12 @@ void log_message(const std::string& message, LogLevel level) {
         case LogLevel::ERR: level_str = "ERROR"; break;
     }
 
-    logfile << std::put_time(std::localtime(&now_time_t), "%Y-%m-%d %H:%M:%S")
+    std::lock_guard<std::mutex> lock(log_mutex);
+    std::ofstream logfile("torrent_builder.log", std::ios_base::app);
+
+    struct tm tm_buf;
+    localtime_r(&now_time_t, &tm_buf);
+
+    logfile << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S")
             << " [" << level_str << "] - " << message << "\n";
 }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -6,7 +6,7 @@
  * The file is opened and closed on each call to ensure entries are flushed
  * even if the process terminates unexpectedly (e.g., std::exit).
  *
- * Thread safety: Thread-safe. Uses an internal mutex and localtime_r.
+ * Thread safety: Thread-safe. Uses an internal mutex and platform-safe localtime.
  */
 
 #include "logger.hpp"
@@ -15,6 +15,16 @@
 #include <iomanip>
 #include <ctime>
 #include <mutex>
+
+namespace {
+void portable_localtime(const time_t* timer, tm* result) {
+#ifdef _WIN32
+    localtime_s(result, timer);
+#else
+    localtime_r(timer, result);
+#endif
+}
+}
 
 void log_message(const std::string& message, LogLevel level) {
     static std::mutex log_mutex;
@@ -33,7 +43,7 @@ void log_message(const std::string& message, LogLevel level) {
     std::ofstream logfile("torrent_builder.log", std::ios_base::app);
 
     struct tm tm_buf;
-    localtime_r(&now_time_t, &tm_buf);
+    portable_localtime(&now_time_t, &tm_buf);
 
     logfile << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S")
             << " [" << level_str << "] - " << message << "\n";

--- a/src/preset.cpp
+++ b/src/preset.cpp
@@ -1,0 +1,174 @@
+#include "preset.hpp"
+#include "logger.hpp"
+#include "utils.hpp"
+#include "constants.hpp"
+#include "torrent_creator.hpp"
+#include <yaml-cpp/yaml.h>
+#include <cstdlib>
+#include <regex>
+#include <ranges>
+
+ConfigValues parse_yaml_config(const YAML::Node& node)
+{
+    ConfigValues cv;
+
+    if (node["trackers"]) {
+        std::vector<std::string> trackers;
+        for (const auto& t : node["trackers"]) {
+            auto url = t.as<std::string>();
+            if (!utils::is_valid_url(url)) {
+                throw std::runtime_error("Invalid tracker URL in config: " + url);
+            }
+            trackers.push_back(url);
+        }
+        cv.trackers = std::move(trackers);
+    }
+
+    if (node["web_seeds"]) {
+        std::vector<std::string> seeds;
+        for (const auto& s : node["web_seeds"]) {
+            auto url = s.as<std::string>();
+            if (!utils::is_valid_url(url)) {
+                throw std::runtime_error("Invalid web seed URL in config: " + url);
+            }
+            seeds.push_back(url);
+        }
+        cv.web_seeds = std::move(seeds);
+    }
+
+    if (node["private"]) cv.is_private = node["private"].as<bool>();
+    if (node["source"]) cv.source = node["source"].as<std::string>();
+    if (node["piece_size"]) cv.piece_size = node["piece_size"].as<int>();
+    if (node["comment"]) cv.comment = node["comment"].as<std::string>();
+    if (node["creator"]) cv.creator = node["creator"].as<std::string>();
+    if (node["name"]) cv.name = node["name"].as<std::string>();
+    if (node["creation_date"]) cv.creation_date = node["creation_date"].as<bool>();
+    if (node["torrent_version"]) cv.torrent_version = node["torrent_version"].as<int>();
+    if (node["entropy"]) cv.entropy = node["entropy"].as<bool>();
+
+    if (node["exclude_patterns"]) {
+        std::vector<std::string> patterns;
+        for (const auto& p : node["exclude_patterns"]) {
+            patterns.push_back(p.as<std::string>());
+        }
+        cv.exclude_patterns = std::move(patterns);
+    }
+
+    if (node["include_patterns"]) {
+        std::vector<std::string> patterns;
+        for (const auto& p : node["include_patterns"]) {
+            patterns.push_back(p.as<std::string>());
+        }
+        cv.include_patterns = std::move(patterns);
+    }
+
+    return cv;
+}
+
+ConfigValues merge_config_values(const ConfigValues& base, const ConfigValues& overlay)
+{
+    ConfigValues result = base;
+
+    if (overlay.path) result.path = overlay.path;
+    if (overlay.output) result.output = overlay.output;
+    if (overlay.trackers) result.trackers = overlay.trackers;
+    if (overlay.web_seeds) result.web_seeds = overlay.web_seeds;
+    if (overlay.is_private.has_value()) result.is_private = overlay.is_private;
+    if (overlay.source) result.source = overlay.source;
+    if (overlay.piece_size) result.piece_size = overlay.piece_size;
+    if (overlay.comment) result.comment = overlay.comment;
+    if (overlay.creator) result.creator = overlay.creator;
+    if (overlay.name) result.name = overlay.name;
+    if (overlay.creation_date.has_value()) result.creation_date = overlay.creation_date;
+    if (overlay.torrent_version) result.torrent_version = overlay.torrent_version;
+    if (overlay.entropy.has_value()) result.entropy = overlay.entropy;
+    if (overlay.exclude_patterns) result.exclude_patterns = overlay.exclude_patterns;
+    if (overlay.include_patterns) result.include_patterns = overlay.include_patterns;
+
+    return result;
+}
+
+fs::path PresetLoader::find_preset_file(const std::optional<fs::path>& explicit_path)
+{
+    if (explicit_path) {
+        if (!fs::exists(*explicit_path)) {
+            throw std::runtime_error("Preset file not found: " + explicit_path->string());
+        }
+        return *explicit_path;
+    }
+
+    fs::path cwd_preset = fs::current_path() / "presets.yaml";
+    if (fs::exists(cwd_preset)) {
+        return cwd_preset;
+    }
+
+    const char* xdg_config = std::getenv("XDG_CONFIG_HOME");
+    fs::path config_dir;
+    if (xdg_config && xdg_config[0] != '\0') {
+        config_dir = fs::path(xdg_config) / "torrent-builder" / "presets.yaml";
+    } else {
+        const char* home = std::getenv("HOME");
+        if (home) {
+            config_dir = fs::path(home) / ".config" / "torrent-builder" / "presets.yaml";
+        }
+    }
+
+    if (!config_dir.empty() && fs::exists(config_dir)) {
+        return config_dir;
+    }
+
+    throw std::runtime_error("No preset file found. Searched: ./presets.yaml"
+        + (config_dir.empty() ? std::string() : ", " + config_dir.string())
+        + ". Use --preset-file to specify a path.");
+}
+
+void PresetLoader::load(const fs::path& path)
+{
+    static constexpr std::uintmax_t max_yaml_size = 1 * 1024 * 1024;
+    if (fs::file_size(path) > max_yaml_size) {
+        throw std::runtime_error("Preset file too large (max 1 MB): " + path.string());
+    }
+
+    YAML::Node root = YAML::LoadFile(path.string());
+
+    if (!root["version"] || root["version"].as<int>() != 1) {
+        throw std::runtime_error("Unsupported preset file version (expected: 1)");
+    }
+
+    if (root["default"]) {
+        defaults_ = parse_yaml_config(root["default"]);
+    }
+
+    if (root["presets"]) {
+        for (const auto& entry : root["presets"]) {
+            std::string name = entry.first.as<std::string>();
+            presets_[name] = parse_yaml_config(entry.second);
+        }
+    }
+
+    log_message("Loaded presets from: " + path.string()
+        + " (" + std::to_string(presets_.size()) + " presets)", LogLevel::INFO);
+}
+
+ConfigValues PresetLoader::resolve(const std::string& name) const
+{
+    auto it = presets_.find(name);
+    if (it == presets_.end()) {
+        std::string available;
+        bool first = true;
+        for (const auto& [k, _] : presets_) {
+            if (!first) available += ", ";
+            available += k;
+            first = false;
+        }
+        throw std::runtime_error("Unknown preset: '" + name + "'. Available: "
+            + (presets_.empty() ? std::string("(none)") : available));
+    }
+
+    return merge_config_values(defaults_, it->second);
+}
+
+bool PresetLoader::has_preset(const std::string& name) const
+{
+    return presets_.count(name) > 0;
+}

--- a/src/torrent_builder.cpp
+++ b/src/torrent_builder.cpp
@@ -4,14 +4,18 @@
 #include "utils.hpp"
 #include "terminal.hpp"
 #include "version.hpp"
+#include "preset.hpp"
+#include "batch.hpp"
 #include <iostream>
 #include <vector>
 #include <optional>
 #include <cxxopts.hpp>
 #include <filesystem>
 #include <cmath>
+#include <chrono>
 #include <ranges>
 #include <stdexcept>
+#include <yaml-cpp/exceptions.h>
 #include "torrent_inspector.hpp"
 #include "torrent_modifier.hpp"
 #include "torrent_checker.hpp"
@@ -429,29 +433,46 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
 
     std::string input_path = result["path"].as<std::string>();
 
+    ConfigValues preset_values;
+    if (result.count("preset"))
+    {
+        std::optional<fs::path> preset_file;
+        if (result.count("preset-file")) {
+            preset_file = result["preset-file"].as<std::string>();
+        }
+        PresetLoader loader;
+        auto path = PresetLoader::find_preset_file(preset_file);
+        loader.load(path);
+        preset_values = loader.resolve(result["preset"].as<std::string>());
+        log_message("Applied preset values for: " + result["preset"].as<std::string>(), LogLevel::INFO);
+    }
+
     // Get trackers (before output, needed for auto-naming)
     std::vector<std::string> trackers;
-    bool use_default = result.count("default-trackers") > 0;
-
-    if (use_default)
-    {
-        trackers.insert(trackers.end(), default_trackers.begin(), default_trackers.end());
-    }
-    if (result.count("tracker"))
-    {
-        std::vector<std::string> custom_trackers = result["tracker"].as<std::vector<std::string>>();
-        for (const auto &tracker : custom_trackers)
+    if (!result.count("tracker") && !result.count("default-trackers") && preset_values.trackers) {
+        trackers = *preset_values.trackers;
+    } else {
+        bool use_default = result.count("default-trackers") > 0;
+        if (use_default)
         {
-            if (!utils::is_valid_url(tracker))
-            {
-                throw std::runtime_error("Invalid tracker URL: " + tracker);
-            }
-            if (std::ranges::contains(trackers, tracker))
-            {
-                throw std::runtime_error("Duplicate tracker URL: " + tracker);
-            }
+            trackers.insert(trackers.end(), default_trackers.begin(), default_trackers.end());
         }
-        trackers.insert(trackers.end(), custom_trackers.begin(), custom_trackers.end());
+        if (result.count("tracker"))
+        {
+            std::vector<std::string> custom_trackers = result["tracker"].as<std::vector<std::string>>();
+            for (const auto &tracker : custom_trackers)
+            {
+                if (!utils::is_valid_url(tracker))
+                {
+                    throw std::runtime_error("Invalid tracker URL: " + tracker);
+                }
+                if (std::ranges::contains(trackers, tracker))
+                {
+                    throw std::runtime_error("Duplicate tracker URL: " + tracker);
+                }
+            }
+            trackers.insert(trackers.end(), custom_trackers.begin(), custom_trackers.end());
+        }
     }
 
     // Resolve output path (optional — auto-generate if not provided)
@@ -513,11 +534,16 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
     }
 
     // Get torrent version
-    std::string version = result["torrent-version"].as<std::string>();
+    std::string version_str = "3";
+    if (result.count("torrent-version")) {
+        version_str = result["torrent-version"].as<std::string>();
+    } else if (preset_values.torrent_version) {
+        version_str = std::to_string(*preset_values.torrent_version);
+    }
     TorrentVersion tv = TorrentVersion::V1;
-    if (version == "2")
+    if (version_str == "2")
         tv = TorrentVersion::V2;
-    else if (version == "3")
+    else if (version_str == "3")
         tv = TorrentVersion::HYBRID;
 
     // Get optional comment
@@ -525,6 +551,10 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
     if (result.count("comment"))
     {
         comment = result["comment"].as<std::string>();
+    }
+    else if (preset_values.comment)
+    {
+        comment = preset_values.comment;
     }
 
     // Get optional torrent name
@@ -534,6 +564,10 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
         if (torrent_name->find_first_not_of(" \t\n\r") == std::string::npos) {
             throw std::runtime_error("Torrent name cannot be empty or whitespace-only");
         }
+    }
+    else if (preset_values.name)
+    {
+        torrent_name = preset_values.name;
     }
 
     // Get web seeds
@@ -548,6 +582,10 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
                 throw std::runtime_error("Invalid web seed URL: " + webseed);
             }
         }
+    }
+    else if (preset_values.web_seeds)
+    {
+        web_seeds = *preset_values.web_seeds;
     }
 
     // Get and validate piece size
@@ -576,6 +614,14 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
             throw std::runtime_error("Invalid piece size");
         }
     }
+    else if (preset_values.piece_size && *preset_values.piece_size > 0)
+    {
+        int ps = *preset_values.piece_size;
+        if (std::ranges::contains(allowed_piece_sizes, ps))
+        {
+            piece_size = ps * 1024;
+        }
+    }
 
     // Get creator string
     std::optional<std::string> creator_str = std::nullopt;
@@ -583,9 +629,16 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
     {
         creator_str = "Torrent Builder";
     }
+    else if (preset_values.creator)
+    {
+        creator_str = preset_values.creator;
+    }
 
     // Get creation date flag
     bool include_creation_date = result.count("creation-date") > 0;
+    if (!include_creation_date && preset_values.creation_date) {
+        include_creation_date = *preset_values.creation_date;
+    }
 
     // Get optional source string
     std::optional<std::string> source = std::nullopt;
@@ -597,9 +650,16 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
             source = source_str;
         }
     }
+    else if (preset_values.source)
+    {
+        source = preset_values.source;
+    }
 
     // Get entropy flag
     bool entropy = result.count("entropy") > 0;
+    if (!entropy && preset_values.entropy) {
+        entropy = *preset_values.entropy;
+    }
 
     // Compile glob patterns to regex once at config time. glob_to_regex() escapes
     // all metacharacters so regex_error is unreachable — the catch is defense-in-depth.
@@ -608,6 +668,14 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
     {
         auto patterns = result["exclude"].as<std::vector<std::string>>();
         for (const auto &p : patterns)
+        {
+            try { exclude_regex_compiled.push_back(utils::glob_to_regex(p)); }
+            catch (const std::regex_error &) { throw std::runtime_error("Invalid exclude pattern: " + p); }
+        }
+    }
+    else if (preset_values.exclude_patterns)
+    {
+        for (const auto &p : *preset_values.exclude_patterns)
         {
             try { exclude_regex_compiled.push_back(utils::glob_to_regex(p)); }
             catch (const std::regex_error &) { throw std::runtime_error("Invalid exclude pattern: " + p); }
@@ -624,11 +692,24 @@ std::optional<TorrentConfig> get_commandline_config(const cxxopts::ParseResult &
             catch (const std::regex_error &) { throw std::runtime_error("Invalid include pattern: " + p); }
         }
     }
+    else if (preset_values.include_patterns)
+    {
+        for (const auto &p : *preset_values.include_patterns)
+        {
+            try { include_regex_compiled.push_back(utils::glob_to_regex(p)); }
+            catch (const std::regex_error &) { throw std::runtime_error("Invalid include pattern: " + p); }
+        }
+    }
 
     try
     {
+        bool is_private = result.count("private") > 0;
+        if (!is_private && preset_values.is_private) {
+            is_private = *preset_values.is_private;
+        }
+
         return TorrentConfig(input_path, output_path, trackers, tv,
-                             comment, result.count("private") > 0, web_seeds, piece_size,
+                             comment, is_private, web_seeds, piece_size,
                              creator_str, torrent_name, include_creation_date,
                              source, entropy,
                              std::move(exclude_regex_compiled), std::move(include_regex_compiled)
@@ -969,6 +1050,90 @@ int handle_check_command(const std::vector<std::string> &args)
     }
 }
 
+int handle_batch_command(const std::vector<std::string> &args)
+{
+    try
+    {
+        int argc = static_cast<int>(args.size()) + 1;
+        std::vector<const char *> argv;
+        argv.push_back("torrent-builder");
+        for (const auto &arg : args)
+        {
+            argv.push_back(arg.c_str());
+        }
+
+        cxxopts::Options batch_options("torrent-builder batch", "Batch create torrents from YAML config");
+        batch_options.add_options()
+            ("h,help", "Show help")
+            ("w,workers", "Number of parallel workers", cxxopts::value<int>()->default_value("1"), "N")
+            ("path", "Batch YAML file", cxxopts::value<std::string>(), "FILE");
+
+        batch_options.parse_positional({"path"});
+        auto result = batch_options.parse(argc, argv.data());
+
+        if (result.count("help") || !result.count("path"))
+        {
+            print_info(batch_options.help() + "\n");
+            print_info("Examples:\n");
+            print_info("  torrent-builder batch batch.yaml\n");
+            print_info("  torrent-builder batch batch.yaml --workers 4\n");
+            return 0;
+        }
+
+        set_verbosity(Verbosity::QUIET);
+
+        BatchConfig config = BatchProcessor::parse(result["path"].as<std::string>());
+
+        if (result.count("workers")) {
+            int w = result["workers"].as<int>();
+            if (w >= 1) {
+                config.workers = w;
+            } else {
+                print_error("Warning: Ignored --workers value: must be >= 1, using " + std::to_string(config.workers));
+                log_message("Ignored --workers value: must be >= 1, using " + std::to_string(config.workers), LogLevel::WARNING);
+            }
+        }
+
+        BatchProcessor processor(std::move(config));
+        auto batch_start = std::chrono::steady_clock::now();
+        auto results = processor.run();
+        auto batch_end = std::chrono::steady_clock::now();
+        double batch_elapsed = std::chrono::duration<double>(batch_end - batch_start).count();
+        BatchProcessor::print_summary(results);
+        log_message("Batch completed in " + std::to_string(batch_elapsed) + "s", LogLevel::INFO);
+
+        for (const auto &r : results)
+        {
+            if (!r.success) return 1;
+        }
+        return 0;
+    }
+    catch (const std::filesystem::filesystem_error &e)
+    {
+        log_message(std::string("Batch filesystem error: ") + e.what(), LogLevel::ERR);
+        print_error(std::string("Filesystem error: ") + e.what() + "\n");
+        return 1;
+    }
+    catch (const YAML::Exception &e)
+    {
+        log_message(std::string("Batch YAML error: ") + e.what(), LogLevel::ERR);
+        print_error(std::string("YAML parsing error: ") + e.what() + "\n");
+        return 1;
+    }
+    catch (const std::runtime_error &e)
+    {
+        log_message(std::string("Batch error: ") + e.what(), LogLevel::ERR);
+        print_error(std::string(e.what()) + "\n");
+        return 1;
+    }
+    catch (const std::exception &e)
+    {
+        log_message(std::string("Unexpected batch error: ") + e.what(), LogLevel::ERR);
+        print_error(std::string("An unexpected error occurred: ") + e.what() + "\n");
+        return 1;
+    }
+}
+
 int main(int argc, char *argv[])
 {
     // Check for subcommands
@@ -1000,6 +1165,16 @@ int main(int argc, char *argv[])
             args.push_back(argv[i]);
         }
         return handle_check_command(args);
+    }
+
+    if (argc >= 2 && std::string(argv[1]) == "batch")
+    {
+        std::vector<std::string> args;
+        for (int i = 2; i < argc; ++i)
+        {
+            args.push_back(argv[i]);
+        }
+        return handle_batch_command(args);
     }
 
     try
@@ -1035,7 +1210,9 @@ int main(int argc, char *argv[])
             "x,exclude", "Exclude files matching glob pattern (supports *, **, ?)",
              cxxopts::value<std::vector<std::string>>(), "PATTERN")(
             "I,include", "Include only files matching glob pattern (supports *, **, ?)",
-             cxxopts::value<std::vector<std::string>>(), "PATTERN");
+             cxxopts::value<std::vector<std::string>>(), "PATTERN")(
+            "preset", "Apply named preset from presets.yaml", cxxopts::value<std::string>(), "NAME")(
+            "preset-file", "Load presets from specified file", cxxopts::value<std::string>(), "FILE");
 
         options.positional_help("PATH [OUTPUT]");
         options.parse_positional({"path", "output"});

--- a/src/torrent_creator.cpp
+++ b/src/torrent_creator.cpp
@@ -16,8 +16,8 @@
 #include <system_error>
 
 // Constructor for TorrentCreator
-TorrentCreator::TorrentCreator(const TorrentConfig& config)
-    : config_(config), ses(lt::session_params{}) {
+TorrentCreator::TorrentCreator(TorrentConfig config)
+    : config_(std::move(config)), ses(lt::session_params{}) {
 }
 
 

--- a/src/torrent_creator.cpp
+++ b/src/torrent_creator.cpp
@@ -320,6 +320,7 @@ void TorrentCreator::hash_large_file(const fs::path& path, lt::create_torrent& t
 
 // Displays a progress bar
 void TorrentCreator::print_progress_bar(int progress, int total, double speed, double eta, int64_t processed, int64_t total_size) const {
+    if (config_.silent) return;
     print_progress(progress, total, speed, eta, processed, total_size);
 }
 

--- a/tests/portable.hpp
+++ b/tests/portable.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef _WIN32
+#include <process.h>
+#define portable_getpid() _getpid()
+#else
+#include <unistd.h>
+#define portable_getpid() getpid()
+#endif

--- a/tests/test_batch.cpp
+++ b/tests/test_batch.cpp
@@ -1,0 +1,664 @@
+#include <gtest/gtest.h>
+#include "batch.hpp"
+#include "preset.hpp"
+#include "torrent_inspector.hpp"
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+
+class BatchTest : public ::testing::Test {
+protected:
+    fs::path temp_dir;
+
+    void SetUp() override {
+        temp_dir = fs::temp_directory_path() / ("batch_test_" + std::to_string(::getpid()));
+        fs::create_directories(temp_dir);
+    }
+
+    void TearDown() override {
+        fs::remove_all(temp_dir);
+    }
+
+    void write_file(const std::string& name, const std::string& content) {
+        std::ofstream f(temp_dir / name);
+        f << content;
+    }
+};
+
+TEST_F(BatchTest, ParseBasicBatchConfig) {
+    write_file("batch.yaml", R"(
+version: 1
+workers: 2
+jobs:
+  - path: "/tmp/nonexistent1"
+    output: "test1.torrent"
+  - path: "/tmp/nonexistent2"
+    output: "test2.torrent"
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    EXPECT_EQ(config.workers, 2);
+    EXPECT_EQ(config.jobs.size(), 2u);
+    EXPECT_EQ(config.jobs[0].path, "/tmp/nonexistent1");
+    EXPECT_EQ(config.jobs[1].path, "/tmp/nonexistent2");
+}
+
+TEST_F(BatchTest, ParseDefaultWorkers) {
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: "/tmp/test"
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    EXPECT_EQ(config.workers, 1);
+    EXPECT_EQ(config.jobs.size(), 1u);
+}
+
+TEST_F(BatchTest, ParseWithPresetFile) {
+    write_file("batch.yaml", R"(
+version: 1
+preset_file: "/path/to/presets.yaml"
+jobs:
+  - path: "/tmp/test"
+    preset: ptp
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    EXPECT_TRUE(config.preset_file.has_value());
+    EXPECT_EQ(*config.preset_file, "/path/to/presets.yaml");
+    EXPECT_EQ(config.jobs[0].preset.value(), "ptp");
+}
+
+TEST_F(BatchTest, ParseWithOutputDir) {
+    write_file("batch.yaml", R"(
+version: 1
+output_dir: "/tmp/output"
+jobs:
+  - path: "/tmp/test"
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    EXPECT_TRUE(config.output_dir.has_value());
+    EXPECT_EQ(*config.output_dir, "/tmp/output");
+}
+
+TEST_F(BatchTest, ParseJobWithAllFields) {
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: "/tmp/test"
+    output: "test.torrent"
+    trackers:
+      - "https://tracker.example/announce"
+    web_seeds:
+      - "https://ws.example/file"
+    private: true
+    source: "SRC"
+    piece_size: 1024
+    comment: "Test"
+    creator: "TestCreator"
+    name: "custom"
+    creation_date: true
+    torrent_version: 2
+    entropy: true
+    exclude_patterns: ["*.nfo"]
+    include_patterns: ["*.mkv"]
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    const auto& job = config.jobs[0];
+    const auto& cv = job.values;
+
+    ASSERT_TRUE(cv.trackers.has_value());
+    EXPECT_EQ(cv.trackers->size(), 1u);
+    ASSERT_TRUE(cv.web_seeds.has_value());
+    EXPECT_EQ(cv.web_seeds->size(), 1u);
+    EXPECT_TRUE(cv.is_private.has_value() && *cv.is_private);
+    EXPECT_EQ(*cv.source, "SRC");
+    EXPECT_EQ(*cv.piece_size, 1024);
+    EXPECT_EQ(*cv.comment, "Test");
+    EXPECT_EQ(*cv.creator, "TestCreator");
+    EXPECT_EQ(*cv.name, "custom");
+    EXPECT_TRUE(*cv.creation_date);
+    EXPECT_EQ(*cv.torrent_version, 2);
+    EXPECT_TRUE(*cv.entropy);
+    ASSERT_TRUE(cv.exclude_patterns.has_value());
+    EXPECT_EQ(cv.exclude_patterns->size(), 1u);
+    ASSERT_TRUE(cv.include_patterns.has_value());
+    EXPECT_EQ(cv.include_patterns->size(), 1u);
+}
+
+TEST_F(BatchTest, ParseOutputWithoutTorrentExtensionAutoAppends) {
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: "/tmp/test"
+    output: "my_output"
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    ASSERT_EQ(config.jobs.size(), 1u);
+    ASSERT_TRUE(config.jobs[0].output.has_value());
+    EXPECT_EQ(*config.jobs[0].output, "my_output.torrent");
+}
+
+TEST_F(BatchTest, ParseOutputWithTorrentExtensionPreserved) {
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: "/tmp/test"
+    output: "my_output.torrent"
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    ASSERT_EQ(config.jobs.size(), 1u);
+    ASSERT_TRUE(config.jobs[0].output.has_value());
+    EXPECT_EQ(*config.jobs[0].output, "my_output.torrent");
+}
+
+TEST_F(BatchTest, ParseOutputWithUppercaseTorrentExtensionPreserved) {
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: "/tmp/test"
+    output: "my_output.TORRENT"
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    ASSERT_EQ(config.jobs.size(), 1u);
+    ASSERT_TRUE(config.jobs[0].output.has_value());
+    EXPECT_EQ(*config.jobs[0].output, "my_output.TORRENT");
+}
+
+TEST_F(BatchTest, ParseFileTooLargeThrows) {
+    write_file("batch.yaml", std::string(1024 * 1024 + 100, ' '));
+    EXPECT_THROW(BatchProcessor::parse(temp_dir / "batch.yaml"), std::runtime_error);
+}
+
+TEST_F(BatchTest, ParseMissingVersionThrows) {
+    write_file("batch.yaml", R"(
+jobs:
+  - path: "/tmp/test"
+)");
+
+    EXPECT_THROW(BatchProcessor::parse(temp_dir / "batch.yaml"), std::runtime_error);
+}
+
+TEST_F(BatchTest, ParseInvalidVersionThrows) {
+    write_file("batch.yaml", R"(
+version: 2
+jobs:
+  - path: "/tmp/test"
+)");
+
+    EXPECT_THROW(BatchProcessor::parse(temp_dir / "batch.yaml"), std::runtime_error);
+}
+
+TEST_F(BatchTest, ParseMissingJobsThrows) {
+    write_file("batch.yaml", R"(
+version: 1
+)");
+
+    EXPECT_THROW(BatchProcessor::parse(temp_dir / "batch.yaml"), std::runtime_error);
+}
+
+TEST_F(BatchTest, ParseMissingPathThrows) {
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - output: "test.torrent"
+)");
+
+    EXPECT_THROW(BatchProcessor::parse(temp_dir / "batch.yaml"), std::runtime_error);
+}
+
+TEST_F(BatchTest, ParseInvalidWorkersThrows) {
+    write_file("batch.yaml", R"(
+version: 1
+workers: 0
+jobs:
+  - path: "/tmp/test"
+)");
+
+    EXPECT_THROW(BatchProcessor::parse(temp_dir / "batch.yaml"), std::runtime_error);
+}
+
+TEST_F(BatchTest, ParseFileNotFoundThrows) {
+    EXPECT_THROW(
+        BatchProcessor::parse(temp_dir / "nonexistent.yaml"),
+        std::runtime_error);
+}
+
+TEST_F(BatchTest, PrintSummaryDoesNotCrash) {
+    std::vector<BatchResult> results;
+    results.push_back({0, "test1.torrent", true, "", 1.5});
+    results.push_back({1, "test2.torrent", false, "File not found", 0.1});
+
+    EXPECT_NO_THROW(BatchProcessor::print_summary(results));
+}
+
+TEST_F(BatchTest, RunSingleJobSuccess) {
+    fs::path test_file = temp_dir / "testfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'A');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "output.torrent").string() + R"("
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].success);
+    EXPECT_TRUE(results[0].error_message.empty());
+    EXPECT_GT(results[0].elapsed_seconds, 0.0);
+
+    EXPECT_TRUE(fs::exists(temp_dir / "output.torrent"));
+}
+
+TEST_F(BatchTest, RunFailedJobDoesNotCrash) {
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: "/tmp/this_file_does_not_exist_12345"
+    output: "/tmp/should_not_create.torrent"
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_FALSE(results[0].success);
+    EXPECT_FALSE(results[0].error_message.empty());
+}
+
+TEST_F(BatchTest, PrintSummaryWithControlCharactersDoesNotCrash) {
+    std::vector<BatchResult> results;
+    results.push_back({0, "test\x01\x02\x03.torrent", true, "", 1.5});
+    results.push_back({1, "bad\x1b[31m.torrent", false, "error\x00\x7fmsg", 0.1});
+
+    EXPECT_NO_THROW(BatchProcessor::print_summary(results));
+}
+
+TEST_F(BatchTest, RunWithExcludePatternsEndToEnd) {
+    fs::path content_dir = temp_dir / "content";
+    fs::create_directories(content_dir);
+    { std::ofstream(content_dir / "movie.mkv") << "video content"; }
+    { std::ofstream(content_dir / "info.nfo") << "nfo data"; }
+    { std::ofstream(content_dir / "readme.txt") << "text data"; }
+
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: ")" + content_dir.string() + R"("
+    output: ")" + (temp_dir / "filtered.torrent").string() + R"("
+    torrent_version: 1
+    exclude_patterns: ["*.nfo", "*.txt"]
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].success);
+    EXPECT_TRUE(fs::exists(temp_dir / "filtered.torrent"));
+
+    TorrentInspector inspector((temp_dir / "filtered.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    ASSERT_EQ(meta.files.size(), 1u) << "Should only have movie.mkv (nfo and txt excluded)";
+    EXPECT_NE(meta.files[0].path.find("movie.mkv"), std::string::npos);
+}
+
+#ifndef _WIN32
+TEST_F(BatchTest, ParseInaccessibleFileThrows) {
+    auto sub_dir = temp_dir / "restricted";
+    fs::create_directories(sub_dir);
+    write_file("restricted/batch.yaml", R"(
+version: 1
+jobs:
+  - path: "/tmp/test"
+)");
+
+    fs::permissions(sub_dir, fs::perms::none);
+
+    EXPECT_THROW(
+        BatchProcessor::parse(sub_dir / "batch.yaml"),
+        std::filesystem::filesystem_error);
+
+    fs::permissions(sub_dir, fs::perms::all);
+}
+#endif
+
+TEST_F(BatchTest, RunMultipleJobsMixedResults) {
+    fs::path test_file = temp_dir / "goodfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'B');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("batch.yaml", R"(
+version: 1
+workers: 2
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "good.torrent").string() + R"("
+  - path: "/tmp/nonexistent_file_xyz"
+    output: "/tmp/bad.torrent"
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "good2.torrent").string() + R"("
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 3u);
+    EXPECT_TRUE(results[0].success);
+    EXPECT_FALSE(results[1].success);
+    EXPECT_TRUE(results[2].success);
+
+    EXPECT_TRUE(fs::exists(temp_dir / "good.torrent"));
+    EXPECT_TRUE(fs::exists(temp_dir / "good2.torrent"));
+}
+
+TEST_F(BatchTest, RunAutoOutputPath) {
+    fs::path test_file = temp_dir / "auto_output.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(2048, 'C');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("batch.yaml", R"(
+version: 1
+output_dir: ")" + temp_dir.string() + R"("
+jobs:
+  - path: ")" + test_file.string() + R"("
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].success);
+    EXPECT_TRUE(results[0].error_message.empty());
+}
+
+TEST_F(BatchTest, RunWithPresetEndToEnd) {
+    fs::path test_file = temp_dir / "preset_test.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'D');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("presets.yaml", R"(
+version: 1
+default:
+  private: true
+presets:
+  custom:
+    comment: "from preset"
+    source: "PRESET_SRC"
+)");
+
+    write_file("batch.yaml", R"(
+version: 1
+preset_file: ")" + (temp_dir / "presets.yaml").string() + R"("
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "preset_out.torrent").string() + R"("
+    preset: custom
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].success);
+    EXPECT_TRUE(fs::exists(temp_dir / "preset_out.torrent"));
+}
+
+TEST_F(BatchTest, RunWithUnknownPresetFails) {
+    fs::path test_file = temp_dir / "testfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'A');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("presets.yaml", R"(
+version: 1
+presets:
+  ptp:
+    source: "PTP"
+)");
+
+    write_file("batch.yaml", R"(
+version: 1
+preset_file: ")" + (temp_dir / "presets.yaml").string() + R"("
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "out.torrent").string() + R"("
+    preset: nonexistent_preset
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_FALSE(results[0].success);
+    EXPECT_NE(results[0].error_message.find("Unknown preset"), std::string::npos);
+}
+
+TEST_F(BatchTest, RunWithoutPresetFileContinues) {
+    fs::path test_file = temp_dir / "testfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'A');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "out.torrent").string() + R"("
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].success);
+    EXPECT_TRUE(fs::exists(temp_dir / "out.torrent"));
+}
+
+TEST_F(BatchTest, RunWithInvalidPresetPieceSizeFails) {
+    fs::path test_file = temp_dir / "testfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'A');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("presets.yaml", R"(
+version: 1
+presets:
+  bad_piecesize:
+    piece_size: 999
+)");
+
+    write_file("batch.yaml", R"(
+version: 1
+preset_file: ")" + (temp_dir / "presets.yaml").string() + R"("
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "out.torrent").string() + R"("
+    preset: bad_piecesize
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_FALSE(results[0].success);
+    EXPECT_NE(results[0].error_message.find("Invalid piece size"), std::string::npos);
+}
+
+TEST_F(BatchTest, WorkersCappedWhenExceedingJobCount) {
+    write_file("batch.yaml", R"(
+version: 1
+workers: 100
+jobs:
+  - path: "/tmp/nonexistent_path_for_test"
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_FALSE(results[0].success);
+}
+
+TEST_F(BatchTest, RunWithOutputDirAutoCreate) {
+    fs::path test_file = temp_dir / "testfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'A');
+        f.write(data.data(), data.size());
+    }
+
+    fs::path nested_output = temp_dir / "nested" / "output";
+
+    write_file("batch.yaml", R"(
+version: 1
+output_dir: ")" + nested_output.string() + R"("
+jobs:
+  - path: ")" + test_file.string() + R"("
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].success);
+    EXPECT_TRUE(fs::is_directory(nested_output)) << "Output directory should have been auto-created";
+}
+
+TEST_F(BatchTest, RunWithHybridVersion) {
+    fs::path test_file = temp_dir / "testfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'A');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "hybrid.torrent").string() + R"("
+    torrent_version: 3
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].success);
+}
+
+TEST_F(BatchTest, RunWithV1Version) {
+    fs::path test_file = temp_dir / "testfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'A');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "v1.torrent").string() + R"("
+    torrent_version: 1
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].success);
+}
+
+TEST_F(BatchTest, RunWithPieceSize) {
+    fs::path test_file = temp_dir / "testfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(32 * 1024, 'A');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "piecesize.torrent").string() + R"("
+    piece_size: 16
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_TRUE(results[0].success);
+}
+
+TEST_F(BatchTest, RunWithInvalidPieceSizeFails) {
+    fs::path test_file = temp_dir / "testfile.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'A');
+        f.write(data.data(), data.size());
+    }
+
+    write_file("batch.yaml", R"(
+version: 1
+jobs:
+  - path: ")" + test_file.string() + R"("
+    output: ")" + (temp_dir / "out.torrent").string() + R"("
+    piece_size: 999
+)");
+
+    auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
+    BatchProcessor processor(std::move(config));
+    auto results = processor.run();
+
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_FALSE(results[0].success);
+    EXPECT_NE(results[0].error_message.find("Invalid piece size"), std::string::npos);
+}

--- a/tests/test_batch.cpp
+++ b/tests/test_batch.cpp
@@ -1,3 +1,4 @@
+#include "portable.hpp"
 #include <gtest/gtest.h>
 #include "batch.hpp"
 #include "preset.hpp"
@@ -12,7 +13,7 @@ protected:
     fs::path temp_dir;
 
     void SetUp() override {
-        temp_dir = fs::temp_directory_path() / ("batch_test_" + std::to_string(::getpid()));
+        temp_dir = fs::temp_directory_path() / ("batch_test_" + std::to_string(portable_getpid()));
         fs::create_directories(temp_dir);
     }
 
@@ -250,8 +251,8 @@ TEST_F(BatchTest, RunSingleJobSuccess) {
     write_file("batch.yaml", R"(
 version: 1
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "output.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "output.torrent").generic_string() + R"("
 )");
 
     auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
@@ -301,8 +302,8 @@ TEST_F(BatchTest, RunWithExcludePatternsEndToEnd) {
     write_file("batch.yaml", R"(
 version: 1
 jobs:
-  - path: ")" + content_dir.string() + R"("
-    output: ")" + (temp_dir / "filtered.torrent").string() + R"("
+  - path: ")" + content_dir.generic_string() + R"("
+    output: ")" + (temp_dir / "filtered.torrent").generic_string() + R"("
     torrent_version: 1
     exclude_patterns: ["*.nfo", "*.txt"]
 )");
@@ -353,12 +354,12 @@ TEST_F(BatchTest, RunMultipleJobsMixedResults) {
 version: 1
 workers: 2
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "good.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "good.torrent").generic_string() + R"("
   - path: "/tmp/nonexistent_file_xyz"
     output: "/tmp/bad.torrent"
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "good2.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "good2.torrent").generic_string() + R"("
 )");
 
     auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
@@ -384,9 +385,9 @@ TEST_F(BatchTest, RunAutoOutputPath) {
 
     write_file("batch.yaml", R"(
 version: 1
-output_dir: ")" + temp_dir.string() + R"("
+output_dir: ")" + temp_dir.generic_string() + R"("
 jobs:
-  - path: ")" + test_file.string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
 )");
 
     auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
@@ -418,10 +419,10 @@ presets:
 
     write_file("batch.yaml", R"(
 version: 1
-preset_file: ")" + (temp_dir / "presets.yaml").string() + R"("
+preset_file: ")" + (temp_dir / "presets.yaml").generic_string() + R"("
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "preset_out.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "preset_out.torrent").generic_string() + R"("
     preset: custom
 )");
 
@@ -451,10 +452,10 @@ presets:
 
     write_file("batch.yaml", R"(
 version: 1
-preset_file: ")" + (temp_dir / "presets.yaml").string() + R"("
+preset_file: ")" + (temp_dir / "presets.yaml").generic_string() + R"("
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "out.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "out.torrent").generic_string() + R"("
     preset: nonexistent_preset
 )");
 
@@ -478,8 +479,8 @@ TEST_F(BatchTest, RunWithoutPresetFileContinues) {
     write_file("batch.yaml", R"(
 version: 1
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "out.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "out.torrent").generic_string() + R"("
 )");
 
     auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
@@ -508,10 +509,10 @@ presets:
 
     write_file("batch.yaml", R"(
 version: 1
-preset_file: ")" + (temp_dir / "presets.yaml").string() + R"("
+preset_file: ")" + (temp_dir / "presets.yaml").generic_string() + R"("
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "out.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "out.torrent").generic_string() + R"("
     preset: bad_piecesize
 )");
 
@@ -552,9 +553,9 @@ TEST_F(BatchTest, RunWithOutputDirAutoCreate) {
 
     write_file("batch.yaml", R"(
 version: 1
-output_dir: ")" + nested_output.string() + R"("
+output_dir: ")" + nested_output.generic_string() + R"("
 jobs:
-  - path: ")" + test_file.string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
 )");
 
     auto config = BatchProcessor::parse(temp_dir / "batch.yaml");
@@ -577,8 +578,8 @@ TEST_F(BatchTest, RunWithHybridVersion) {
     write_file("batch.yaml", R"(
 version: 1
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "hybrid.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "hybrid.torrent").generic_string() + R"("
     torrent_version: 3
 )");
 
@@ -601,8 +602,8 @@ TEST_F(BatchTest, RunWithV1Version) {
     write_file("batch.yaml", R"(
 version: 1
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "v1.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "v1.torrent").generic_string() + R"("
     torrent_version: 1
 )");
 
@@ -625,8 +626,8 @@ TEST_F(BatchTest, RunWithPieceSize) {
     write_file("batch.yaml", R"(
 version: 1
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "piecesize.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "piecesize.torrent").generic_string() + R"("
     piece_size: 16
 )");
 
@@ -649,8 +650,8 @@ TEST_F(BatchTest, RunWithInvalidPieceSizeFails) {
     write_file("batch.yaml", R"(
 version: 1
 jobs:
-  - path: ")" + test_file.string() + R"("
-    output: ")" + (temp_dir / "out.torrent").string() + R"("
+  - path: ")" + test_file.generic_string() + R"("
+    output: ")" + (temp_dir / "out.torrent").generic_string() + R"("
     piece_size: 999
 )");
 

--- a/tests/test_checker.cpp
+++ b/tests/test_checker.cpp
@@ -1,3 +1,4 @@
+#include "portable.hpp"
 #include <gtest/gtest.h>
 #include <fstream>
 #include <filesystem>
@@ -23,7 +24,7 @@ class CheckerTest : public ::testing::Test
 
     void SetUp() override
     {
-        temp_dir_ = fs::temp_directory_path() / ("torrent_checker_test_" + std::to_string(::getpid()));
+        temp_dir_ = fs::temp_directory_path() / ("torrent_checker_test_" + std::to_string(portable_getpid()));
         content_dir_ = temp_dir_ / "content";
         fs::create_directories(content_dir_);
         torrent_path_ = temp_dir_ / "test.torrent";
@@ -401,7 +402,7 @@ class V2CheckerTest : public ::testing::Test
 
     void SetUp() override
     {
-        temp_dir_ = fs::temp_directory_path() / ("torrent_checker_v2_" + std::to_string(::getpid()));
+        temp_dir_ = fs::temp_directory_path() / ("torrent_checker_v2_" + std::to_string(portable_getpid()));
         content_dir_ = temp_dir_ / "content";
         fs::create_directories(content_dir_);
         torrent_path_ = temp_dir_ / "test.torrent";
@@ -541,7 +542,7 @@ class HybridCheckerTest : public ::testing::Test
 
     void SetUp() override
     {
-        temp_dir_ = fs::temp_directory_path() / ("torrent_checker_hybrid_" + std::to_string(::getpid()));
+        temp_dir_ = fs::temp_directory_path() / ("torrent_checker_hybrid_" + std::to_string(portable_getpid()));
         content_dir_ = temp_dir_ / "content";
         fs::create_directories(content_dir_);
         torrent_path_ = temp_dir_ / "test.torrent";
@@ -631,7 +632,7 @@ class HybridMultiFileCheckerTest : public ::testing::Test
 
     void SetUp() override
     {
-        temp_dir_ = fs::temp_directory_path() / ("torrent_checker_hybrid_multi_" + std::to_string(::getpid()));
+        temp_dir_ = fs::temp_directory_path() / ("torrent_checker_hybrid_multi_" + std::to_string(portable_getpid()));
         content_dir_ = temp_dir_ / "content";
         fs::create_directories(content_dir_);
         torrent_path_ = temp_dir_ / "test.torrent";

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -2505,8 +2505,260 @@ TEST(CLI, CheckCommandDetectsCorruption) {
      EXPECT_NE(output.find("FAIL"), std::string::npos);
      EXPECT_NE(output.find("Corrupted pieces"), std::string::npos);
 
-     std::error_code ec;
-     fs::remove_all(temp_dir, ec);
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST(BatchCLI, ShowsHelp) {
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() + " batch --help 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_NE(output.find("batch"), std::string::npos);
+}
+
+TEST(BatchCLI, MissingFileReturnsError) {
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() + " batch /nonexistent_batch_file.yaml 2>&1", exit_code);
+    EXPECT_NE(exit_code, 0);
+    EXPECT_NE(output.find("not found"), std::string::npos);
+}
+
+TEST(BatchCLI, InvalidYamlReturnsError) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_test_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+    {
+        std::ofstream f(temp_dir / "batch.yaml");
+        f << "not: valid: yaml: [[[";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() + " batch " + (temp_dir / "batch.yaml").string() + " 2>&1", exit_code);
+    EXPECT_NE(exit_code, 0);
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(BatchCLI, ValidBatchCreatesTorrents) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_valid_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "batch.yaml");
+        f << "version: 1\n"
+           << "jobs:\n"
+           << "  - path: \"" << test_file.string() << "\"\n"
+           << "    output: \"" << (temp_dir / "out.torrent").string() << "\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() + " batch " + (temp_dir / "batch.yaml").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_NE(output.find("Succeeded: 1"), std::string::npos);
+    EXPECT_TRUE(fs::exists(temp_dir / "out.torrent"));
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, UnknownPresetReturnsError) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_test_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() + " --preset nonexistent --preset-file " +
+        (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_NE(exit_code, 0);
+    EXPECT_NE(output.find("Preset file not found"), std::string::npos);
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, ValidPresetAppliedToTorrent) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_valid_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+           << "presets:\n"
+           << "  mypreset:\n"
+           << "    comment: \"preset test comment\"\n"
+           << "    source: \"PRESET_CLI\"\n"
+           << "    private: true\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_TRUE(fs::exists(temp_dir / "out.torrent"));
+    EXPECT_NE(output.find("Private: Yes"), std::string::npos);
+    EXPECT_NE(output.find("PRESET_CLI"), std::string::npos);
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    ASSERT_TRUE(meta.source.has_value());
+    EXPECT_EQ(*meta.source, "PRESET_CLI");
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, PresetTrackersAppliedWhenNoCLIFlags) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_trackers_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+           << "presets:\n"
+           << "  mypreset:\n"
+           << "    trackers:\n"
+           << "      - \"https://tracker.example.com/announce\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_NE(output.find("Trackers: 1"), std::string::npos) << "Output: " << output;
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, CLITrackerOverridesPresetTrackers) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_tracker_override_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+           << "presets:\n"
+           << "  mypreset:\n"
+           << "    trackers:\n"
+           << "      - \"https://preset-tracker.example.com/announce\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -T https://cli-tracker.example.com/announce" +
+        " -p " + test_file.string() +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    ASSERT_EQ(meta.trackers.size(), 1u);
+    EXPECT_NE(meta.trackers[0].find("cli-tracker.example.com"), std::string::npos);
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(BatchCLI, WorkersOverride) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_workers_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "batch.yaml");
+        f << "version: 1\n"
+           << "jobs:\n"
+           << "  - path: \"" << test_file.string() << "\"\n"
+           << "    output: \"" << (temp_dir / "out.torrent").string() << "\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() + " batch " + (temp_dir / "batch.yaml").string() +
+        " --workers 2 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_NE(output.find("Succeeded: 1"), std::string::npos);
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(BatchCLI, WorkersZeroShowsWarning) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_w0_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "batch.yaml");
+        f << "version: 1\n"
+           << "jobs:\n"
+           << "  - path: \"" << test_file.string() << "\"\n"
+           << "    output: \"" << (temp_dir / "out.torrent").string() << "\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() + " batch " + (temp_dir / "batch.yaml").string() +
+        " --workers 0 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+    EXPECT_NE(output.find("Warning"), std::string::npos) << "Expected warning about --workers 0";
+    EXPECT_NE(output.find("Succeeded: 1"), std::string::npos);
+
+    fs::remove_all(temp_dir);
 }
 
 TEST(CLI, CheckCommandVerboseOutput) {
@@ -2554,4 +2806,376 @@ TEST(CLI, CheckCommandDefaultPath) {
 
     std::error_code ec;
     fs::remove_all(temp_dir, ec);
+}
+
+TEST(PresetCLI, PresetCreatorAppliedToTorrent) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_creator_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+           << "presets:\n"
+           << "  mypreset:\n"
+           << "    creator: \"PresetCreator\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    ASSERT_TRUE(meta.created_by.has_value());
+    EXPECT_EQ(*meta.created_by, "PresetCreator");
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, PresetNameAppliedToTorrent) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_name_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+           << "presets:\n"
+           << "  mypreset:\n"
+           << "    name: \"CustomName\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -t 1" +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_EQ(meta.name, "CustomName");
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, PresetEntropyAppliedToTorrent) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_entropy_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+           << "presets:\n"
+           << "  mypreset:\n"
+           << "    entropy: true\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -t 1" +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_TRUE(meta.entropy.has_value());
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(BatchCLI, FailedJobReturnsExitCode1) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_fail_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    {
+        std::ofstream f(temp_dir / "batch.yaml");
+        f << "version: 1\n"
+           << "jobs:\n"
+           << "  - path: \"/nonexistent/path/that/does/not/exist\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() + " batch " + (temp_dir / "batch.yaml").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 1) << "Expected exit code 1 for failed batch job. Output: " << output;
+    EXPECT_NE(output.find("Failed: 1"), std::string::npos);
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, UnknownPresetNameWithValidFileReturnsError) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_unknown_name_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+          << "presets:\n"
+          << "  mypreset:\n"
+          << "    source: \"TEST\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset nonexistent_preset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_NE(exit_code, 0);
+    EXPECT_NE(output.find("Unknown preset"), std::string::npos) << "Output: " << output;
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, PresetPieceSizeAppliedToTorrent) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_piecesize_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(32 * 1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+          << "presets:\n"
+          << "  mypreset:\n"
+          << "    piece_size: 16\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -t 1" +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_EQ(meta.piece_length, 16 * 1024) << "Piece length should be 16 KB (16384 bytes)";
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, PresetCreationDateAppliedToTorrent) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_creationdate_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+          << "presets:\n"
+          << "  mypreset:\n"
+          << "    creation_date: true\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -t 1" +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_TRUE(meta.creation_date.has_value()) << "Creation date should be present when preset sets it to true";
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, PresetTorrentVersionAppliedToTorrent) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_version_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+          << "presets:\n"
+          << "  mypreset:\n"
+          << "    torrent_version: 1\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_FALSE(meta.info_hash_v1.empty()) << "V1 torrent should have v1 info hash";
+    EXPECT_TRUE(meta.info_hash_v2.empty()) << "V1 torrent should not have v2 info hash";
+    EXPECT_FALSE(meta.is_hybrid) << "V1 torrent should not be hybrid";
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, PresetExcludePatternsAppliedToTorrent) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_exclude_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path content_dir = temp_dir / "content";
+    fs::create_directories(content_dir);
+    { std::ofstream(content_dir / "movie.mkv") << "video content"; }
+    { std::ofstream(content_dir / "info.nfo") << "nfo data"; }
+    { std::ofstream(content_dir / "readme.txt") << "text data"; }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+          << "presets:\n"
+          << "  mypreset:\n"
+          << "    exclude_patterns:\n"
+          << "      - \"*.nfo\"\n"
+          << "      - \"*.txt\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + content_dir.string() +
+        " -t 1" +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    ASSERT_EQ(meta.files.size(), 1u) << "Should only have movie.mkv (nfo and txt excluded via preset)";
+    EXPECT_NE(meta.files[0].path.find("movie.mkv"), std::string::npos);
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, PresetIncludePatternsAppliedToTorrent) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_include_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path content_dir = temp_dir / "content";
+    fs::create_directories(content_dir);
+    { std::ofstream(content_dir / "movie.mkv") << "video content"; }
+    { std::ofstream(content_dir / "clip.mp4") << "clip content"; }
+    { std::ofstream(content_dir / "readme.txt") << "text data"; }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+          << "presets:\n"
+          << "  mypreset:\n"
+          << "    include_patterns:\n"
+          << "      - \"*.mkv\"\n"
+          << "      - \"*.mp4\"\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + content_dir.string() +
+        " -t 1" +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Output: " << output;
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    ASSERT_EQ(meta.files.size(), 2u) << "Should have 2 files (mkv and mp4 included via preset, txt excluded)";
+
+    fs::remove_all(temp_dir);
+}
+
+TEST(PresetCLI, PresetInvalidPieceSizeFallsBackToDefault) {
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_invalid_ps_" + std::to_string(getpid()));
+    fs::create_directories(temp_dir);
+
+    fs::path test_file = temp_dir / "content.bin";
+    {
+        std::ofstream f(test_file, std::ios::binary);
+        std::vector<char> data(32 * 1024, 'X');
+        f.write(data.data(), data.size());
+    }
+
+    {
+        std::ofstream f(temp_dir / "presets.yaml");
+        f << "version: 1\n"
+          << "presets:\n"
+          << "  mypreset:\n"
+          << "    piece_size: 999\n";
+    }
+
+    int exit_code = -1;
+    std::string output = exec_command(
+        get_binary_path() +
+        " --preset mypreset --preset-file " + (temp_dir / "presets.yaml").string() +
+        " -p " + test_file.string() +
+        " -t 1" +
+        " -o " + (temp_dir / "out.torrent").string() + " 2>&1", exit_code);
+    EXPECT_EQ(exit_code, 0) << "Should succeed with auto-calculated piece size. Output: " << output;
+    EXPECT_TRUE(fs::exists(temp_dir / "out.torrent"));
+
+    TorrentInspector inspector((temp_dir / "out.torrent").string());
+    TorrentMetadata meta = inspector.inspect();
+    EXPECT_NE(meta.piece_length, 999 * 1024) << "Invalid preset piece_size should not be applied";
+    EXPECT_GT(meta.piece_length, 0) << "Auto-calculated piece size should be positive";
+
+    fs::remove_all(temp_dir);
 }

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -1,3 +1,4 @@
+#include "portable.hpp"
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <cstdio>
@@ -2526,7 +2527,7 @@ TEST(BatchCLI, MissingFileReturnsError) {
 }
 
 TEST(BatchCLI, InvalidYamlReturnsError) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_test_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_test_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
     {
         std::ofstream f(temp_dir / "batch.yaml");
@@ -2542,7 +2543,7 @@ TEST(BatchCLI, InvalidYamlReturnsError) {
 }
 
 TEST(BatchCLI, ValidBatchCreatesTorrents) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_valid_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_valid_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2556,8 +2557,8 @@ TEST(BatchCLI, ValidBatchCreatesTorrents) {
         std::ofstream f(temp_dir / "batch.yaml");
         f << "version: 1\n"
            << "jobs:\n"
-           << "  - path: \"" << test_file.string() << "\"\n"
-           << "    output: \"" << (temp_dir / "out.torrent").string() << "\"\n";
+           << "  - path: \"" << test_file.generic_string() << "\"\n"
+           << "    output: \"" << (temp_dir / "out.torrent").generic_string() << "\"\n";
     }
 
     int exit_code = -1;
@@ -2571,7 +2572,7 @@ TEST(BatchCLI, ValidBatchCreatesTorrents) {
 }
 
 TEST(PresetCLI, UnknownPresetReturnsError) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_test_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_test_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2594,7 +2595,7 @@ TEST(PresetCLI, UnknownPresetReturnsError) {
 }
 
 TEST(PresetCLI, ValidPresetAppliedToTorrent) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_valid_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_valid_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2634,7 +2635,7 @@ TEST(PresetCLI, ValidPresetAppliedToTorrent) {
 }
 
 TEST(PresetCLI, PresetTrackersAppliedWhenNoCLIFlags) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_trackers_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_trackers_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2666,7 +2667,7 @@ TEST(PresetCLI, PresetTrackersAppliedWhenNoCLIFlags) {
 }
 
 TEST(PresetCLI, CLITrackerOverridesPresetTrackers) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_tracker_override_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_tracker_override_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2703,7 +2704,7 @@ TEST(PresetCLI, CLITrackerOverridesPresetTrackers) {
 }
 
 TEST(BatchCLI, WorkersOverride) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_workers_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_workers_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2717,8 +2718,8 @@ TEST(BatchCLI, WorkersOverride) {
         std::ofstream f(temp_dir / "batch.yaml");
         f << "version: 1\n"
            << "jobs:\n"
-           << "  - path: \"" << test_file.string() << "\"\n"
-           << "    output: \"" << (temp_dir / "out.torrent").string() << "\"\n";
+           << "  - path: \"" << test_file.generic_string() << "\"\n"
+           << "    output: \"" << (temp_dir / "out.torrent").generic_string() << "\"\n";
     }
 
     int exit_code = -1;
@@ -2732,7 +2733,7 @@ TEST(BatchCLI, WorkersOverride) {
 }
 
 TEST(BatchCLI, WorkersZeroShowsWarning) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_w0_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_w0_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2746,8 +2747,8 @@ TEST(BatchCLI, WorkersZeroShowsWarning) {
         std::ofstream f(temp_dir / "batch.yaml");
         f << "version: 1\n"
            << "jobs:\n"
-           << "  - path: \"" << test_file.string() << "\"\n"
-           << "    output: \"" << (temp_dir / "out.torrent").string() << "\"\n";
+           << "  - path: \"" << test_file.generic_string() << "\"\n"
+           << "    output: \"" << (temp_dir / "out.torrent").generic_string() << "\"\n";
     }
 
     int exit_code = -1;
@@ -2809,7 +2810,7 @@ TEST(CLI, CheckCommandDefaultPath) {
 }
 
 TEST(PresetCLI, PresetCreatorAppliedToTorrent) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_creator_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_creator_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2844,7 +2845,7 @@ TEST(PresetCLI, PresetCreatorAppliedToTorrent) {
 }
 
 TEST(PresetCLI, PresetNameAppliedToTorrent) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_name_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_name_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2879,7 +2880,7 @@ TEST(PresetCLI, PresetNameAppliedToTorrent) {
 }
 
 TEST(PresetCLI, PresetEntropyAppliedToTorrent) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_entropy_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_entropy_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2914,7 +2915,7 @@ TEST(PresetCLI, PresetEntropyAppliedToTorrent) {
 }
 
 TEST(BatchCLI, FailedJobReturnsExitCode1) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_fail_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_batch_fail_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     {
@@ -2934,7 +2935,7 @@ TEST(BatchCLI, FailedJobReturnsExitCode1) {
 }
 
 TEST(PresetCLI, UnknownPresetNameWithValidFileReturnsError) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_unknown_name_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_unknown_name_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -2965,7 +2966,7 @@ TEST(PresetCLI, UnknownPresetNameWithValidFileReturnsError) {
 }
 
 TEST(PresetCLI, PresetPieceSizeAppliedToTorrent) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_piecesize_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_piecesize_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -3000,7 +3001,7 @@ TEST(PresetCLI, PresetPieceSizeAppliedToTorrent) {
 }
 
 TEST(PresetCLI, PresetCreationDateAppliedToTorrent) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_creationdate_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_creationdate_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -3035,7 +3036,7 @@ TEST(PresetCLI, PresetCreationDateAppliedToTorrent) {
 }
 
 TEST(PresetCLI, PresetTorrentVersionAppliedToTorrent) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_version_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_version_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";
@@ -3071,7 +3072,7 @@ TEST(PresetCLI, PresetTorrentVersionAppliedToTorrent) {
 }
 
 TEST(PresetCLI, PresetExcludePatternsAppliedToTorrent) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_exclude_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_exclude_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path content_dir = temp_dir / "content";
@@ -3108,7 +3109,7 @@ TEST(PresetCLI, PresetExcludePatternsAppliedToTorrent) {
 }
 
 TEST(PresetCLI, PresetIncludePatternsAppliedToTorrent) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_include_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_include_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path content_dir = temp_dir / "content";
@@ -3144,7 +3145,7 @@ TEST(PresetCLI, PresetIncludePatternsAppliedToTorrent) {
 }
 
 TEST(PresetCLI, PresetInvalidPieceSizeFallsBackToDefault) {
-    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_invalid_ps_" + std::to_string(getpid()));
+    fs::path temp_dir = fs::temp_directory_path() / ("cli_preset_invalid_ps_" + std::to_string(portable_getpid()));
     fs::create_directories(temp_dir);
 
     fs::path test_file = temp_dir / "content.bin";

--- a/tests/test_preset.cpp
+++ b/tests/test_preset.cpp
@@ -1,3 +1,4 @@
+#include "portable.hpp"
 #include <gtest/gtest.h>
 #include "preset.hpp"
 #include <filesystem>
@@ -6,12 +7,30 @@
 
 namespace fs = std::filesystem;
 
+namespace {
+void portable_setenv(const std::string& key, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(key.c_str(), value.c_str());
+#else
+    setenv(key.c_str(), value.c_str(), 1);
+#endif
+}
+
+void portable_unsetenv(const std::string& key) {
+#ifdef _WIN32
+    _putenv_s(key.c_str(), "");
+#else
+    unsetenv(key.c_str());
+#endif
+}
+}
+
 class PresetTest : public ::testing::Test {
 protected:
     fs::path temp_dir;
 
     void SetUp() override {
-        temp_dir = fs::temp_directory_path() / ("preset_test_" + std::to_string(::getpid()));
+        temp_dir = fs::temp_directory_path() / ("preset_test_" + std::to_string(portable_getpid()));
         fs::create_directories(temp_dir);
     }
 
@@ -228,20 +247,19 @@ TEST_F(PresetTest, FindPresetFileNoFileThrows) {
     auto old_cwd = fs::current_path();
     auto old_xdg = std::getenv("XDG_CONFIG_HOME");
 
-    fs::path isolated_cwd = temp_dir / ("no_preset_cwd_" + std::to_string(::getpid()));
+    fs::path isolated_cwd = temp_dir / ("no_preset_cwd_" + std::to_string(portable_getpid()));
     fs::create_directories(isolated_cwd);
     fs::current_path(isolated_cwd);
-    setenv("XDG_CONFIG_HOME", (temp_dir / "nonexistent_xdg").string().c_str(), 1);
+    portable_setenv("XDG_CONFIG_HOME", (temp_dir / "nonexistent_xdg").string());
 
     EXPECT_THROW(
         PresetLoader::find_preset_file(std::nullopt),
         std::runtime_error);
 
     fs::current_path(old_cwd);
+    portable_unsetenv("XDG_CONFIG_HOME");
     if (old_xdg && old_xdg[0] != '\0') {
-        setenv("XDG_CONFIG_HOME", old_xdg, 1);
-    } else {
-        unsetenv("XDG_CONFIG_HOME");
+        portable_setenv("XDG_CONFIG_HOME", old_xdg);
     }
 }
 
@@ -324,10 +342,10 @@ TEST_F(PresetTest, FindPresetFileXDGConfigHome) {
     auto old_cwd = fs::current_path();
     auto old_xdg = std::getenv("XDG_CONFIG_HOME");
 
-    fs::path isolated_cwd = temp_dir / ("isolated_cwd_" + std::to_string(::getpid()));
+    fs::path isolated_cwd = temp_dir / ("isolated_cwd_" + std::to_string(portable_getpid()));
     fs::create_directories(isolated_cwd);
     fs::current_path(isolated_cwd);
-    setenv("XDG_CONFIG_HOME", (temp_dir / "xdg_config").string().c_str(), 1);
+    portable_setenv("XDG_CONFIG_HOME", (temp_dir / "xdg_config").string());
 
     try {
         auto path = PresetLoader::find_preset_file(std::nullopt);
@@ -337,10 +355,9 @@ TEST_F(PresetTest, FindPresetFileXDGConfigHome) {
     }
 
     fs::current_path(old_cwd);
+    portable_unsetenv("XDG_CONFIG_HOME");
     if (old_xdg && old_xdg[0] != '\0') {
-        setenv("XDG_CONFIG_HOME", old_xdg, 1);
-    } else {
-        unsetenv("XDG_CONFIG_HOME");
+        portable_setenv("XDG_CONFIG_HOME", old_xdg);
     }
 }
 
@@ -348,28 +365,28 @@ TEST_F(PresetTest, FindPresetFileCwdFound) {
     auto old_cwd = fs::current_path();
     auto old_xdg = std::getenv("XDG_CONFIG_HOME");
 
-    fs::path cwd_dir = temp_dir / ("cwd_preset_" + std::to_string(::getpid()));
+    fs::path cwd_dir = temp_dir / ("cwd_preset_" + std::to_string(portable_getpid()));
     fs::create_directories(cwd_dir);
     {
         std::ofstream f(cwd_dir / "presets.yaml");
         f << "version: 1\npresets: {}\n";
     }
 
-    setenv("XDG_CONFIG_HOME", (temp_dir / "nonexistent_xdg").string().c_str(), 1);
+    portable_setenv("XDG_CONFIG_HOME", (temp_dir / "nonexistent_xdg").string());
     fs::current_path(cwd_dir);
 
     try {
         auto path = PresetLoader::find_preset_file(std::nullopt);
-        EXPECT_EQ(path, cwd_dir / "presets.yaml");
+        auto expected = fs::current_path() / "presets.yaml";
+        EXPECT_EQ(path, expected);
     } catch (...) {
         FAIL() << "Should have found preset in CWD";
     }
 
     fs::current_path(old_cwd);
+    portable_unsetenv("XDG_CONFIG_HOME");
     if (old_xdg && old_xdg[0] != '\0') {
-        setenv("XDG_CONFIG_HOME", old_xdg, 1);
-    } else {
-        unsetenv("XDG_CONFIG_HOME");
+        portable_setenv("XDG_CONFIG_HOME", old_xdg);
     }
 }
 

--- a/tests/test_preset.cpp
+++ b/tests/test_preset.cpp
@@ -1,0 +1,406 @@
+#include <gtest/gtest.h>
+#include "preset.hpp"
+#include <filesystem>
+#include <fstream>
+#include <cstdlib>
+
+namespace fs = std::filesystem;
+
+class PresetTest : public ::testing::Test {
+protected:
+    fs::path temp_dir;
+
+    void SetUp() override {
+        temp_dir = fs::temp_directory_path() / ("preset_test_" + std::to_string(::getpid()));
+        fs::create_directories(temp_dir);
+    }
+
+    void TearDown() override {
+        fs::remove_all(temp_dir);
+    }
+
+    void write_file(const std::string& name, const std::string& content) {
+        std::ofstream f(temp_dir / name);
+        f << content;
+    }
+};
+
+TEST_F(PresetTest, MergeOverlayWinsForTrackers) {
+    ConfigValues base;
+    base.trackers = std::vector<std::string>{"https://a.com/announce"};
+
+    ConfigValues overlay;
+    overlay.trackers = std::vector<std::string>{"https://b.com/announce"};
+
+    auto result = merge_config_values(base, overlay);
+    ASSERT_TRUE(result.trackers.has_value());
+    EXPECT_EQ(result.trackers->size(), 1u);
+    EXPECT_EQ((*result.trackers)[0], "https://b.com/announce");
+}
+
+TEST_F(PresetTest, MergeBaseUsedWhenOverlayMissing) {
+    ConfigValues base;
+    base.source = "BASE";
+    base.is_private = true;
+
+    ConfigValues overlay;
+
+    auto result = merge_config_values(base, overlay);
+    EXPECT_TRUE(result.source.has_value());
+    EXPECT_EQ(*result.source, "BASE");
+    EXPECT_TRUE(result.is_private.has_value());
+    EXPECT_TRUE(*result.is_private);
+}
+
+TEST_F(PresetTest, MergeBothEmpty) {
+    ConfigValues base;
+    ConfigValues overlay;
+    auto result = merge_config_values(base, overlay);
+    EXPECT_FALSE(result.path.has_value());
+    EXPECT_FALSE(result.trackers.has_value());
+}
+
+TEST_F(PresetTest, MergeExplicitFalseOverridesTrue) {
+    ConfigValues base;
+    base.is_private = true;
+    base.creation_date = true;
+    base.entropy = true;
+
+    ConfigValues overlay;
+    overlay.is_private = false;
+    overlay.creation_date = false;
+    overlay.entropy = false;
+
+    auto result = merge_config_values(base, overlay);
+    ASSERT_TRUE(result.is_private.has_value());
+    EXPECT_FALSE(*result.is_private);
+    ASSERT_TRUE(result.creation_date.has_value());
+    EXPECT_FALSE(*result.creation_date);
+    ASSERT_TRUE(result.entropy.has_value());
+    EXPECT_FALSE(*result.entropy);
+}
+
+TEST_F(PresetTest, MergeAllFieldsOverridden) {
+    ConfigValues base;
+    base.path = "base_path";
+    base.output = "base_output";
+    base.trackers = std::vector<std::string>{"a"};
+    base.web_seeds = std::vector<std::string>{"b"};
+    base.is_private = true;
+    base.source = "base_source";
+    base.piece_size = 1024;
+    base.comment = "base_comment";
+    base.creator = "base_creator";
+    base.name = "base_name";
+    base.creation_date = true;
+    base.torrent_version = 1;
+    base.entropy = true;
+    base.exclude_patterns = std::vector<std::string>{"*.nfo"};
+    base.include_patterns = std::vector<std::string>{"*.mkv"};
+
+    ConfigValues overlay;
+    overlay.path = "overlay_path";
+    overlay.output = "overlay_output";
+    overlay.trackers = std::vector<std::string>{"c"};
+    overlay.web_seeds = std::vector<std::string>{"d"};
+    overlay.is_private = false;
+    overlay.source = "overlay_source";
+    overlay.piece_size = 2048;
+    overlay.comment = "overlay_comment";
+    overlay.creator = "overlay_creator";
+    overlay.name = "overlay_name";
+    overlay.creation_date = false;
+    overlay.torrent_version = 2;
+    overlay.entropy = false;
+    overlay.exclude_patterns = std::vector<std::string>{"*.txt"};
+    overlay.include_patterns = std::vector<std::string>{"*.mp4"};
+
+    auto result = merge_config_values(base, overlay);
+
+    EXPECT_EQ(*result.path, "overlay_path");
+    EXPECT_EQ(*result.output, "overlay_output");
+    EXPECT_EQ(result.trackers->size(), 1u);
+    EXPECT_EQ((*result.trackers)[0], "c");
+    EXPECT_EQ(result.web_seeds->size(), 1u);
+    EXPECT_EQ((*result.web_seeds)[0], "d");
+    EXPECT_FALSE(*result.is_private);
+    EXPECT_EQ(*result.source, "overlay_source");
+    EXPECT_EQ(*result.piece_size, 2048);
+    EXPECT_EQ(*result.comment, "overlay_comment");
+    EXPECT_EQ(*result.creator, "overlay_creator");
+    EXPECT_EQ(*result.name, "overlay_name");
+    EXPECT_FALSE(*result.creation_date);
+    EXPECT_EQ(*result.torrent_version, 2);
+    EXPECT_FALSE(*result.entropy);
+    EXPECT_EQ(result.exclude_patterns->size(), 1u);
+    EXPECT_EQ((*result.exclude_patterns)[0], "*.txt");
+    EXPECT_EQ(result.include_patterns->size(), 1u);
+    EXPECT_EQ((*result.include_patterns)[0], "*.mp4");
+}
+
+TEST_F(PresetTest, LoadAndResolvePreset) {
+    write_file("presets.yaml", R"(
+version: 1
+default:
+  private: true
+  exclude_patterns: ["*.nfo"]
+presets:
+  ptp:
+    source: "PTP"
+    trackers:
+      - "https://ptp.example/announce"
+    exclude_patterns: ["*.nfo", "*.txt"]
+  public:
+    private: false
+    trackers:
+      - "udp://tracker.example/announce"
+)");
+
+    PresetLoader loader;
+    loader.load(temp_dir / "presets.yaml");
+
+    EXPECT_TRUE(loader.has_preset("ptp"));
+    EXPECT_TRUE(loader.has_preset("public"));
+    EXPECT_FALSE(loader.has_preset("nonexistent"));
+
+    auto ptp = loader.resolve("ptp");
+    EXPECT_TRUE(ptp.is_private.has_value() && *ptp.is_private);
+    EXPECT_TRUE(ptp.source.has_value());
+    EXPECT_EQ(*ptp.source, "PTP");
+    ASSERT_TRUE(ptp.trackers.has_value());
+    EXPECT_EQ(ptp.trackers->size(), 1u);
+    EXPECT_EQ((*ptp.trackers)[0], "https://ptp.example/announce");
+    ASSERT_TRUE(ptp.exclude_patterns.has_value());
+    EXPECT_EQ(ptp.exclude_patterns->size(), 2u);
+
+    auto pub = loader.resolve("public");
+    EXPECT_TRUE(pub.is_private.has_value());
+    EXPECT_FALSE(*pub.is_private);
+    EXPECT_TRUE(pub.exclude_patterns.has_value());
+    EXPECT_EQ(pub.exclude_patterns->size(), 1u);
+}
+
+TEST_F(PresetTest, ResolveUnknownPresetThrows) {
+    write_file("presets.yaml", R"(
+version: 1
+presets: {}
+)");
+
+    PresetLoader loader;
+    loader.load(temp_dir / "presets.yaml");
+
+    EXPECT_THROW(loader.resolve("nonexistent"), std::runtime_error);
+}
+
+TEST_F(PresetTest, LoadInvalidVersionThrows) {
+    write_file("presets.yaml", R"(
+version: 99
+presets: {}
+)");
+
+    PresetLoader loader;
+    EXPECT_THROW(loader.load(temp_dir / "presets.yaml"), std::runtime_error);
+}
+
+TEST_F(PresetTest, LoadMissingVersionThrows) {
+    write_file("presets.yaml", R"(
+presets: {}
+)");
+
+    PresetLoader loader;
+    EXPECT_THROW(loader.load(temp_dir / "presets.yaml"), std::runtime_error);
+}
+
+TEST_F(PresetTest, FindPresetFileExplicitPath) {
+    write_file("presets.yaml", "version: 1\npresets: {}\n");
+
+    auto path = PresetLoader::find_preset_file(temp_dir / "presets.yaml");
+    EXPECT_EQ(path, temp_dir / "presets.yaml");
+}
+
+TEST_F(PresetTest, FindPresetFileExplicitNotFound) {
+    EXPECT_THROW(
+        PresetLoader::find_preset_file(temp_dir / "nonexistent.yaml"),
+        std::runtime_error);
+}
+
+TEST_F(PresetTest, FindPresetFileNoFileThrows) {
+    auto old_cwd = fs::current_path();
+    auto old_xdg = std::getenv("XDG_CONFIG_HOME");
+
+    fs::path isolated_cwd = temp_dir / ("no_preset_cwd_" + std::to_string(::getpid()));
+    fs::create_directories(isolated_cwd);
+    fs::current_path(isolated_cwd);
+    setenv("XDG_CONFIG_HOME", (temp_dir / "nonexistent_xdg").string().c_str(), 1);
+
+    EXPECT_THROW(
+        PresetLoader::find_preset_file(std::nullopt),
+        std::runtime_error);
+
+    fs::current_path(old_cwd);
+    if (old_xdg && old_xdg[0] != '\0') {
+        setenv("XDG_CONFIG_HOME", old_xdg, 1);
+    } else {
+        unsetenv("XDG_CONFIG_HOME");
+    }
+}
+
+TEST_F(PresetTest, LoadAllFieldTypes) {
+    write_file("presets.yaml", R"(
+version: 1
+presets:
+  full:
+    trackers:
+      - "https://t1.com/announce"
+      - "https://t2.com/announce"
+    web_seeds:
+      - "https://ws1.com/file"
+    private: true
+    source: "SRC"
+    piece_size: 4096
+    comment: "Test comment"
+    creator: "TestCreator"
+    name: "custom_name"
+    creation_date: true
+    torrent_version: 2
+    entropy: true
+    exclude_patterns: ["*.nfo", "*.txt"]
+    include_patterns: ["*.mkv", "*.mp4"]
+)");
+
+    PresetLoader loader;
+    loader.load(temp_dir / "presets.yaml");
+
+    auto full = loader.resolve("full");
+    ASSERT_TRUE(full.trackers.has_value());
+    EXPECT_EQ(full.trackers->size(), 2u);
+    ASSERT_TRUE(full.web_seeds.has_value());
+    EXPECT_EQ(full.web_seeds->size(), 1u);
+    EXPECT_TRUE(*full.is_private);
+    EXPECT_EQ(*full.source, "SRC");
+    EXPECT_EQ(*full.piece_size, 4096);
+    EXPECT_EQ(*full.comment, "Test comment");
+    EXPECT_EQ(*full.creator, "TestCreator");
+    EXPECT_EQ(*full.name, "custom_name");
+    EXPECT_TRUE(*full.creation_date);
+    EXPECT_EQ(*full.torrent_version, 2);
+    EXPECT_TRUE(*full.entropy);
+    EXPECT_EQ(full.exclude_patterns->size(), 2u);
+    EXPECT_EQ(full.include_patterns->size(), 2u);
+}
+
+TEST_F(PresetTest, DefaultMergeWithPreset) {
+    write_file("presets.yaml", R"(
+version: 1
+default:
+  private: true
+  exclude_patterns: ["*.nfo"]
+presets:
+  ptp:
+    source: "PTP"
+    trackers:
+      - "https://ptp.example/announce"
+)");
+
+    PresetLoader loader;
+    loader.load(temp_dir / "presets.yaml");
+
+    auto resolved = loader.resolve("ptp");
+    EXPECT_TRUE(resolved.is_private.has_value() && *resolved.is_private);
+    EXPECT_TRUE(resolved.exclude_patterns.has_value());
+    EXPECT_EQ(resolved.exclude_patterns->size(), 1u);
+    EXPECT_EQ((*resolved.exclude_patterns)[0], "*.nfo");
+    EXPECT_EQ(*resolved.source, "PTP");
+}
+
+TEST_F(PresetTest, FindPresetFileXDGConfigHome) {
+    fs::path xdg_dir = temp_dir / "xdg_config" / "torrent-builder";
+    fs::create_directories(xdg_dir);
+    {
+        std::ofstream f(xdg_dir / "presets.yaml");
+        f << "version: 1\npresets: {}\n";
+    }
+
+    auto old_cwd = fs::current_path();
+    auto old_xdg = std::getenv("XDG_CONFIG_HOME");
+
+    fs::path isolated_cwd = temp_dir / ("isolated_cwd_" + std::to_string(::getpid()));
+    fs::create_directories(isolated_cwd);
+    fs::current_path(isolated_cwd);
+    setenv("XDG_CONFIG_HOME", (temp_dir / "xdg_config").string().c_str(), 1);
+
+    try {
+        auto path = PresetLoader::find_preset_file(std::nullopt);
+        EXPECT_EQ(path, xdg_dir / "presets.yaml");
+    } catch (...) {
+        FAIL() << "Should have found preset via XDG_CONFIG_HOME";
+    }
+
+    fs::current_path(old_cwd);
+    if (old_xdg && old_xdg[0] != '\0') {
+        setenv("XDG_CONFIG_HOME", old_xdg, 1);
+    } else {
+        unsetenv("XDG_CONFIG_HOME");
+    }
+}
+
+TEST_F(PresetTest, FindPresetFileCwdFound) {
+    auto old_cwd = fs::current_path();
+    auto old_xdg = std::getenv("XDG_CONFIG_HOME");
+
+    fs::path cwd_dir = temp_dir / ("cwd_preset_" + std::to_string(::getpid()));
+    fs::create_directories(cwd_dir);
+    {
+        std::ofstream f(cwd_dir / "presets.yaml");
+        f << "version: 1\npresets: {}\n";
+    }
+
+    setenv("XDG_CONFIG_HOME", (temp_dir / "nonexistent_xdg").string().c_str(), 1);
+    fs::current_path(cwd_dir);
+
+    try {
+        auto path = PresetLoader::find_preset_file(std::nullopt);
+        EXPECT_EQ(path, cwd_dir / "presets.yaml");
+    } catch (...) {
+        FAIL() << "Should have found preset in CWD";
+    }
+
+    fs::current_path(old_cwd);
+    if (old_xdg && old_xdg[0] != '\0') {
+        setenv("XDG_CONFIG_HOME", old_xdg, 1);
+    } else {
+        unsetenv("XDG_CONFIG_HOME");
+    }
+}
+
+TEST_F(PresetTest, LoadInvalidTrackerUrlThrows) {
+    write_file("presets.yaml", R"(
+version: 1
+presets:
+  bad:
+    trackers:
+      - "not_a_valid_url"
+)");
+
+    PresetLoader loader;
+    EXPECT_THROW(loader.load(temp_dir / "presets.yaml"), std::runtime_error);
+}
+
+TEST_F(PresetTest, LoadInvalidWebSeedUrlThrows) {
+    write_file("presets.yaml", R"(
+version: 1
+presets:
+  bad:
+    web_seeds:
+      - "ftp://[invalid"
+)");
+
+    PresetLoader loader;
+    EXPECT_THROW(loader.load(temp_dir / "presets.yaml"), std::runtime_error);
+}
+
+TEST_F(PresetTest, LoadFileTooLargeThrows) {
+    write_file("presets.yaml", std::string(1024 * 1024 + 100, ' '));
+    PresetLoader loader;
+    EXPECT_THROW(loader.load(temp_dir / "presets.yaml"), std::runtime_error);
+}

--- a/tests/test_terminal.cpp
+++ b/tests/test_terminal.cpp
@@ -1,3 +1,4 @@
+#include "portable.hpp"
 #include <gtest/gtest.h>
 #include "terminal.hpp"
 #include <stdexcept>
@@ -243,7 +244,7 @@ protected:
     int pid_ = -1;
 
     void SetUp() override {
-        tmp_file_ = fs::temp_directory_path() / ("cli_interrupt_" + std::to_string(getpid()));
+        tmp_file_ = fs::temp_directory_path() / ("cli_interrupt_" + std::to_string(portable_getpid()));
         std::ofstream f(tmp_file_, std::ios::binary);
         std::vector<char> data(1024 * 1024, 'A');
         f.write(data.data(), data.size());


### PR DESCRIPTION
## Summary

Add a YAML preset system and parallel batch mode to the torrent builder. Presets allow saving per-tracker configurations (trackers, source, piece size, exclude/include patterns, etc.) in a YAML file with XDG config discovery and hierarchical merge (CLI > preset > defaults). Batch mode reads a YAML job list and processes torrents in parallel using a `std::jthread` worker pool with per-job preset resolution, error isolation, and summary output.

## Motivation

Power users creating torrents for multiple trackers had to repeat the same CLI flags every invocation. The preset system solves this by letting users define per-tracker profiles once. Batch mode further addresses the need to create dozens of torrents in a single pass — essential for tracker release groups and bulk upload workflows. Together they reduce a multi-command manual workflow to a single `torrent-builder batch batch.yaml`.

## Changes Made

- **Thread-safe logger**: `static std::mutex` with `std::lock_guard` for safe concurrent logging. `TorrentCreator` constructor changed to accept `TorrentConfig` by value with `std::move`.
- **Build system**: Added `yaml-cpp` dependency (find_package with FetchContent fallback). New `torrent_builder_config` static library.
- **Preset system**: `ConfigValues` with 14 optional fields, `merge_config_values()` with hierarchical merge, `PresetLoader` with XDG search, URL validation, 1 MB file size limit.
- **Batch mode**: `BatchProcessor` with `std::jthread` worker pool, per-job preset resolution, error isolation, worker cap at `hardware_concurrency() x 2`.
- **CLI integration**: `--preset`/`--preset-file` flags, `batch` subcommand with `--workers`, `YAML::Exception` handling.
- **Tests**: 74 new tests (19 preset + 33 batch + 22 CLI). Total: 477 tests, all passing.
- **Documentation**: README updated with YAML format examples, resolution order, and usage.

## Testing
- [x] Tested locally
- [x] Unit tests added
- [x] Documentation updated

## Breaking Changes

None. All existing APIs and CLI interfaces remain backward compatible.