### PR TITLE
fix(batch): apply output_dir to relative job output paths

### DIFF
--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -72,6 +72,16 @@ TorrentConfig build_torrent_config(const ConfigValues& cv, const fs::path& defau
     fs::path output;
     if (cv.output) {
         output = *cv.output;
+        if (output.is_relative() && !default_output_dir.empty()) {
+            output = default_output_dir / output;
+        }
+        if (!output.parent_path().empty()) {
+            std::error_code ec;
+            fs::create_directories(output.parent_path(), ec);
+            if (ec) {
+                throw std::runtime_error("Failed to create output directory: " + output.parent_path().string() + " (" + ec.message() + ")");
+            }
+        }
     } else {
         auto trackers = cv.trackers.value_or(std::vector<std::string>{});
         fs::path out_dir = default_output_dir.empty() ? fs::current_path() : default_output_dir;


### PR DESCRIPTION
## Summary
Fix batch mode ignoring output_dir when jobs specify a relative output path, and report directory creation errors instead of silently ignoring them.

## Bug Description
- **What was happening:** When a batch job specified a relative output path (e.g., output: "file.torrent") and the batch config had output_dir set, the file was written to CWD instead of output_dir.
- **Expected behavior:** Relative output paths should be resolved against output_dir, matching the behavior of jobs without explicit output.
- **Root cause:** build_torrent_config() used cv.output directly without joining with output_dir when it was already set.

## Changes Made
- Resolve relative output paths against output_dir in build_torrent_config()
- Report directory creation errors with clear message instead of silently ignoring them

## Testing
- [x] Tested locally with manual batch run
- [x] All 73 batch/preset unit and integration tests pass
- [x] No regressions

## Breaking Changes
None