### PR TITLE
feat(update): add self-update command with GitHub Releases integration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libboost-dev libtorrent-rasterbar-dev pkg-config
+          sudo apt-get install -y build-essential cmake libboost-dev libtorrent-rasterbar-dev pkg-config libssl-dev
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Debug
@@ -67,6 +67,8 @@ jobs:
         with:
           msystem: ${{ matrix.msystem }}
           update: false
+          retry: true
+          retry-delay: 30
           install: >-
             git
             base-devel
@@ -74,6 +76,7 @@ jobs:
             ${{ matrix.prefix }}-cmake
             ${{ matrix.prefix }}-libtorrent-rasterbar
             ${{ matrix.prefix }}-pkg-config
+            ${{ matrix.prefix }}-openssl
 
       - name: Configure
         shell: msys2 {0}
@@ -103,10 +106,10 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies
-        run: brew install boost cmake libtorrent-rasterbar pkg-config
+        run: brew install boost cmake libtorrent-rasterbar pkg-config openssl@3
 
       - name: Configure
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
 
       - name: Build
         run: cmake --build build --parallel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libtorrent-rasterbar-dev pkg-config git
+          sudo apt-get install -y build-essential cmake libtorrent-rasterbar-dev pkg-config git libssl-dev
 
       - name: Build
         run: |
@@ -311,6 +311,7 @@ jobs:
             ${{ matrix.prefix }}-cmake
             ${{ matrix.prefix }}-libtorrent-rasterbar
             ${{ matrix.prefix }}-pkg-config
+            ${{ matrix.prefix }}-openssl
 
       - name: Build
         shell: msys2 {0}
@@ -348,12 +349,12 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
-        run: brew install boost cmake libtorrent-rasterbar pkg-config
+        run: brew install boost cmake libtorrent-rasterbar pkg-config openssl@3
 
       - name: Build
         run: |
           mkdir build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DTORRENT_BUILDER_VERSION=${{ steps.version.outputs.VERSION }}
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DTORRENT_BUILDER_VERSION=${{ steps.version.outputs.VERSION }} -DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
           cmake --build . --parallel
 
       - name: Rename and package
@@ -379,6 +380,12 @@ jobs:
 
       - name: List artifacts
         run: ls -la bin/
+
+      - name: Generate SHA-256 checksums
+        run: |
+          cd bin
+          sha256sum torrent_builder_* > checksums.txt
+          cat checksums.txt
 
       - name: Create Release
         uses: softprops/action-gh-release@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,16 +157,23 @@ if(TEST_SOURCES)
 
     target_compile_definitions(torrent_builder_tests PRIVATE
         BINARY_PATH="${CMAKE_BINARY_DIR}/torrent_builder"
+        TORRENT_BUILDER_EXCLUDE_MAIN
     )
 
     target_include_directories(torrent_builder_tests PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
 
     target_link_libraries(torrent_builder_tests PRIVATE
         GTest::gtest_main
         torrent_builder_core
         torrent_builder_config
+        cxxopts::cxxopts
+    )
+
+    target_sources(torrent_builder_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/torrent_builder.cpp
     )
 
     include(GoogleTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ else()
     add_compile_options(-O2)
 endif()
 
+# Find OpenSSL (required for SHA-256 computation)
+find_package(OpenSSL REQUIRED)
+
 # Find Boost (required by libtorrent headers)
 find_package(Boost REQUIRED)
 
@@ -74,6 +77,13 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+# nlohmann/json (JSON parsing for update command)
+FetchContent_Declare(
+    nlohmann_json
+    URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
 # ─── Core library ────────────────────────────────────────────
 add_library(torrent_builder_core STATIC
     src/torrent_creator.cpp
@@ -85,10 +95,12 @@ add_library(torrent_builder_core STATIC
     src/terminal.cpp
     src/output.cpp
     src/season_pack.cpp
+    src/updater.cpp
 )
 
 target_include_directories(torrent_builder_core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${LIBTORRENT_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
 )
@@ -96,6 +108,8 @@ target_include_directories(torrent_builder_core PUBLIC
 target_link_libraries(torrent_builder_core PUBLIC
     ${LIBTORRENT_LIBRARIES}
     ${LIBTORRENT_LDFLAGS}
+    nlohmann_json::nlohmann_json
+    OpenSSL::Crypto
 )
 
 target_compile_options(torrent_builder_core PRIVATE ${LIBTORRENT_CFLAGS})

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The **Torrent Builder** is a command-line tool for creating torrent files, offer
 - Batch mode: create multiple torrents in parallel from a YAML config
 - Configurable output directory (auto-created if needed) and tracker index for filename prefix
 - Season pack detection: warn or fail on incomplete TV season packs (missing episodes)
+- Self-update: check for and install the latest version from GitHub Releases
 
 ## Prerequisites
 
@@ -41,17 +42,17 @@ The **Torrent Builder** is a command-line tool for creating torrent files, offer
 
 Ubuntu/Debian
 ```
-sudo apt install build-essential cmake libtorrent-rasterbar-dev pkg-config
+sudo apt install build-essential cmake libtorrent-rasterbar-dev pkg-config libssl-dev
 ```
 
 Fedora
 ```
-sudo dnf install gcc-c++ cmake rb_libtorrent-devel
+sudo dnf install gcc-c++ cmake rb_libtorrent-devel openssl-devel
 ```
 
 ### macOS
 ```
-brew install cmake libtorrent-rasterbar
+brew install cmake libtorrent-rasterbar openssl@3
 ```
 
 ## Installation
@@ -108,6 +109,39 @@ Edit metadata of an existing .torrent file in-place without re-hashing file cont
 ```
 
 Process multiple torrent creation jobs from a YAML config file in parallel. See the [Batch Mode](#batch-mode-1) section below for details.
+
+### Update
+
+```bash
+./torrent_builder update [options]
+```
+
+Check for newer versions and update the binary in-place from GitHub Releases.
+
+> **Note:** Requires `curl` to be installed and available on the system PATH. On macOS, `unzip` is also required.
+
+**Options:**
+```
+  -h, --help    Show help and usage
+  --check       Only check for available updates (no download)
+  --yes         Skip confirmation prompt
+  --rollback    Restore previous version from backup
+```
+
+**Examples:**
+```bash
+# Check and install the latest version
+./torrent_builder update
+
+# Only check if an update is available
+./torrent_builder update --check
+
+# Update without confirmation prompt (useful for scripts)
+./torrent_builder update --yes
+
+# Restore the previous version after an update
+./torrent_builder update --rollback
+```
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ cmake --build .
 ```
 For an optimized Release build: `cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --build .`.
 
+On macOS, pass the OpenSSL path to CMake since `openssl@3` is keg-only:
+```
+cmake .. -DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
+```
+
 **Note**: The executable will be generated at `build/torrent_builder`. For debugging, use `-DCMAKE_BUILD_TYPE=Debug`. If pkg-config fails, check your installation in Prerequisites.
 
 **Versioning**: When building from a git tag (e.g., `v0.2.0`), the version is automatically detected. Otherwise, the version defaults to `dev`. You can override with `-DTORRENT_BUILDER_VERSION=x.y.z` during cmake configuration. Use `./torrent_builder --version` to check.
@@ -116,15 +121,17 @@ Process multiple torrent creation jobs from a YAML config file in parallel. See 
 ./torrent_builder update [options]
 ```
 
-Check for newer versions and update the binary in-place from GitHub Releases.
+Check for newer versions and update the binary in-place from GitHub Releases. Downloads are verified against SHA-256 checksums published in each release's `checksums.txt`.
 
 > **Note:** Requires `curl` to be installed and available on the system PATH. On macOS, `unzip` is also required.
+
+> **Tip:** If you hit GitHub API rate limits, set the `GITHUB_TOKEN` environment variable with a personal access token to use authenticated requests.
 
 **Options:**
 ```
   -h, --help    Show help and usage
   --check       Only check for available updates (no download)
-  --yes         Skip confirmation prompt
+  -y, --yes     Skip confirmation prompt
   --rollback    Restore previous version from backup
 ```
 

--- a/include/updater.hpp
+++ b/include/updater.hpp
@@ -1,0 +1,234 @@
+#ifndef UPDATER_HPP
+#define UPDATER_HPP
+
+#include <string>
+#include <optional>
+#include <vector>
+#include <functional>
+#include <nlohmann/json.hpp>
+
+/**
+ * @brief Result of perform_update().
+ *
+ * Success       - new binary replaced the current one synchronously.
+ * PendingRestart - replacement was scheduled via async helper (e.g. Windows
+ *                  batch script when the running .exe is locked). The caller
+ *                  must NOT delete new_binary_path; the helper owns it now.
+ */
+enum class UpdateResult {
+    Success,
+    PendingRestart,
+};
+
+/**
+ * @brief Information about the latest GitHub release.
+ */
+struct UpdateInfo
+{
+    std::string version;
+    std::string changelog;
+    int64_t asset_size = 0;
+    nlohmann::json release_json;
+};
+
+/**
+ * @brief Detected OS and CPU architecture for asset matching.
+ */
+struct PlatformInfo
+{
+    std::string os;
+    std::string arch;
+};
+
+/**
+ * @brief Self-update functionality for torrent-builder.
+ *
+ * Checks GitHub Releases for newer versions, downloads the matching
+ * platform binary, and replaces the current binary. On Linux and macOS
+ * the replacement is atomic (rename). On Windows a sidecar batch script
+ * performs the swap after the process exits.
+ * Supports rollback via the --rollback flag.
+ */
+class Updater
+{
+public:
+    /** @brief Function type override for curl execution in tests. */
+    using CurlExecutor = std::function<std::string(const std::string &url, const std::vector<std::string> &extra_args)>;
+    /** @brief Function type override for file download in tests. */
+    using FileDownloader = std::function<bool(const std::string &url, const std::string &dest_path, int64_t expected_size)>;
+    /** @brief Function type override for executable path in tests. */
+    using ExePathProvider = std::function<std::string()>;
+
+    /**
+     * @brief Detect the current OS and CPU architecture.
+     * @return PlatformInfo with os (linux/macos/windows) and arch (amd64/arm64).
+     */
+    static PlatformInfo get_platform_info();
+
+    /**
+     * @brief Get the current application version string.
+     * @return Version string (e.g. "1.2.3" or "dev").
+     */
+    static std::string get_current_version();
+
+    /**
+     * @brief Fetch the latest release information from GitHub.
+     * @return UpdateInfo with version, changelog, and release JSON.
+     * @throws std::runtime_error on network/parse errors or API rate limits.
+     */
+    static UpdateInfo fetch_latest_release();
+
+    /**
+     * @brief Find the matching platform asset URL from a JSON string.
+     * @param release_json JSON string from GitHub API.
+     * @param platform Target platform info.
+     * @return Browser download URL for the matching asset, or std::nullopt.
+     */
+    static std::optional<std::string> find_matching_asset(const std::string &release_json, const PlatformInfo &platform);
+
+    /**
+     * @brief Find the matching platform asset URL from a parsed JSON object.
+     * @param release_json Parsed JSON from GitHub API.
+     * @param platform Target platform info.
+     * @return Browser download URL for the matching asset, or std::nullopt.
+     */
+    static std::optional<std::string> find_matching_asset_from_json(const nlohmann::json &release_json, const PlatformInfo &platform);
+
+    /**
+     * @brief Get the size of a specific asset from the release JSON.
+     * @param release_json Parsed JSON from GitHub API.
+     * @param asset_url Browser download URL of the asset.
+     * @return Asset size in bytes, or 0 if not found.
+     */
+    static int64_t get_asset_size(const nlohmann::json &release_json, const std::string &asset_url);
+
+    /**
+     * @brief Download an asset to a local path using curl.
+     * @param url Browser download URL.
+     * @param dest_path Local filesystem path for the downloaded file.
+     * @param expected_size Expected file size in bytes (0 to skip size limit).
+     * @return true if download succeeded, false otherwise.
+     */
+    static bool download_asset(const std::string &url, const std::string &dest_path, int64_t expected_size = 0);
+
+    /**
+     * @brief Perform the binary swap (current → .old backup, new → current).
+     *
+     * The .old backup is retained on success so that perform_rollback() can
+     * restore the previous version. A stale .old from an earlier update is
+     * replaced atomically at the start of the next call.
+     *
+     * @param new_binary_path Path to the downloaded new binary. Ownership
+     *                        transfers on PendingRestart (the async helper
+     *                        will move and delete it); caller retains
+     *                        ownership on Success.
+     * @param current_binary_path Path to the currently running binary.
+     * @return UpdateResult::Success on synchronous completion,
+     *         UpdateResult::PendingRestart when an async helper is scheduled.
+     * @throws std::runtime_error on filesystem errors.
+     */
+    static UpdateResult perform_update(const std::string &new_binary_path, const std::string &current_binary_path);
+
+    /**
+     * @brief Roll back to the previous version (.old backup).
+     * @param current_binary_path Path to the currently running binary.
+     * @return true on success.
+     * @throws std::runtime_error if no backup exists or swap fails.
+     */
+    static bool perform_rollback(const std::string &current_binary_path);
+
+    /**
+     * @brief Locate the curl executable on the system.
+     * @return Absolute path to curl, or "curl" as fallback.
+     */
+    static std::string find_curl_executable();
+
+    /**
+     * @brief Execute a curl request and return the response body.
+     * @param url URL to fetch.
+     * @param extra_args Additional curl CLI arguments.
+     * @return Response body string.
+     * @throws std::runtime_error on curl execution failure or unsafe URL.
+     */
+    static std::string execute_curl(const std::string &url, const std::vector<std::string> &extra_args = {});
+
+    /**
+     * @brief Fetch checksums.txt content from the latest GitHub release.
+     * @return Checksums file content, or std::nullopt if not available.
+     */
+    static std::optional<std::string> fetch_checksums();
+
+    /**
+     * @brief Fetch checksums.txt content from a parsed release JSON (avoids redundant API call).
+     * @param release_json Already-fetched release JSON.
+     * @return Checksums file content, or std::nullopt if not available.
+     */
+    static std::optional<std::string> fetch_checksums(const nlohmann::json &release_json);
+
+    /**
+     * @brief Look up the SHA-256 hash for a specific asset in checksums content.
+     * @param checksums_content Content of checksums.txt.
+     * @param asset_name Filename to search for.
+     * @return Lowercase hex hash string, or std::nullopt if not found.
+     */
+    static std::optional<std::string> lookup_checksum(const std::string &checksums_content, const std::string &asset_name);
+
+    /**
+     * @brief Verify a file's SHA-256 checksum against an expected hash.
+     * @param filepath Path to the file to verify.
+     * @param expected_hash Expected lowercase hex SHA-256 hash.
+     * @return true if the checksum matches, false otherwise.
+     */
+    static bool verify_checksum(const std::string &filepath, const std::string &expected_hash);
+
+    /**
+     * @brief Get the path to the currently running executable.
+     * @return Absolute path to the executable.
+     */
+    static std::string get_exe_path();
+
+    /** @brief Function type override for binary validation in tests. */
+    using BinaryValidator = std::function<bool(const std::string &filepath)>;
+
+    /** @brief Override curl execution for testing. */
+    static void set_curl_executor_for_testing(CurlExecutor executor);
+    /** @brief Override file download for testing. */
+    static void set_file_downloader_for_testing(FileDownloader downloader);
+    /** @brief Override executable path for testing. */
+    static void set_exe_path_provider_for_testing(ExePathProvider provider);
+    /** @brief Override current version string for testing. */
+    static void set_current_version_for_testing(const std::string &version);
+    /** @brief Override binary validation for testing. */
+    static void set_binary_validator_for_testing(BinaryValidator validator);
+    /** @brief Reset all test overrides to defaults. */
+    static void reset_test_overrides();
+
+    /**
+     * @brief Validate that a URL is safe to pass to a shell command.
+     * @param url URL to validate.
+     * @return true if the URL starts with https:// and contains only safe characters.
+     */
+    static bool is_safe_url(const std::string &url);
+
+    /**
+     * @brief Validate that a file starts with a known binary format magic signature.
+     * @param filepath Path to the file to validate.
+     * @return true if the file starts with ELF, Mach-O, or PE magic bytes.
+     */
+    static bool is_valid_binary(const std::string &filepath);
+
+    /**
+     * @brief Build the command string used to launch a batch script asynchronously on Windows.
+     * The script path is passed via the TB_LAUNCH_SCRIPT environment variable to avoid
+     * cmd.exe expanding %VAR% patterns that may appear in the path.
+     * @return The command string for cmd.exe.
+     */
+    static std::string build_script_launch_cmd();
+
+private:
+    static std::string get_old_binary_path(const std::string &current_path);
+    static bool extract_macos_zip(const std::string &zip_path, const std::string &dest_dir);
+    static bool make_executable(const std::string &path);
+};
+
+#endif

--- a/include/updater.hpp
+++ b/include/updater.hpp
@@ -132,10 +132,11 @@ public:
     /**
      * @brief Roll back to the previous version (.old backup).
      * @param current_binary_path Path to the currently running binary.
-     * @return true on success.
+     * @return UpdateResult::Success on synchronous completion,
+     *         UpdateResult::PendingRestart when an async helper is scheduled (Windows).
      * @throws std::runtime_error if no backup exists or swap fails.
      */
-    static bool perform_rollback(const std::string &current_binary_path);
+    static UpdateResult perform_rollback(const std::string &current_binary_path);
 
     /**
      * @brief Locate the curl executable on the system.
@@ -183,7 +184,7 @@ public:
 
     /**
      * @brief Get the path to the currently running executable.
-     * @return Absolute path to the executable.
+     * @return Absolute path to the executable, or "torrent_builder" as fallback.
      */
     static std::string get_exe_path();
 
@@ -213,9 +214,17 @@ public:
     /**
      * @brief Validate that a file starts with a known binary format magic signature.
      * @param filepath Path to the file to validate.
-     * @return true if the file starts with ELF, Mach-O, or PE magic bytes.
+     * @return true if the file starts with ELF, Mach-O, PE, or ZIP (macOS) magic bytes.
      */
     static bool is_valid_binary(const std::string &filepath);
+
+    /**
+     * @brief Verify a downloaded file exists, is non-empty, and matches expected size.
+     * @param path Path to the downloaded file.
+     * @param expected_size Expected size in bytes (0 to skip size check).
+     * @return true if file is valid, false otherwise.
+     */
+    static bool verify_downloaded_file(const std::string &path, int64_t expected_size);
 
     /**
      * @brief Build the command string used to launch a batch script asynchronously on Windows.

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -274,6 +274,33 @@ void direct_write(const std::filesystem::path &dest, const std::vector<char> &da
  */
 void atomic_write(const std::filesystem::path &dest, const std::vector<char> &data);
 
+/**
+ * @brief Semver version components.
+ */
+struct Version {
+    int major = 0;
+    int minor = 0;
+    int patch = 0;
+    std::string prerelease;
+
+    bool is_prerelease() const { return !prerelease.empty(); }
+};
+
+/**
+ * @brief Parse a semver string into a Version struct.
+ * @param version_str Version string, optionally prefixed with 'v'/'V' or suffixed with '-...'.
+ * @return Parsed Version with major/minor/patch; defaults to 0 on missing or invalid parts.
+ */
+Version parse_version(const std::string &version_str);
+
+/**
+ * @brief Compare two semver strings.
+ * @param v1 First version string.
+ * @param v2 Second version string.
+ * @return -1 if v1 < v2, 0 if equal, 1 if v1 > v2.
+ */
+int compare_versions(const std::string &v1, const std::string &v2);
+
 } // namespace utils
 
 #endif

--- a/src/torrent_builder.cpp
+++ b/src/torrent_builder.cpp
@@ -13,6 +13,7 @@
 #include <cxxopts.hpp>
 #include <filesystem>
 #include <cmath>
+#include <random>
 #include <chrono>
 #include <ranges>
 #include <stdexcept>
@@ -1263,26 +1264,38 @@ int handle_update_command(const std::vector<std::string> &args)
             print_info("Rolling back to previous version...\n");
             log_message("User initiated rollback", LogLevel::INFO);
 
-            if (!prompt_yes_no("Restore previous version?"))
+            if (!result.count("yes") && !prompt_yes_no("Restore previous version?"))
             {
                 print_info("Rollback cancelled.\n");
                 log_message("Rollback cancelled by user", LogLevel::INFO);
                 return 0;
             }
 
-            if (Updater::perform_rollback(exe_path))
+            UpdateResult rollback_result = Updater::perform_rollback(exe_path);
+            if (rollback_result == UpdateResult::Success)
             {
                 print_info("Successfully rolled back to previous version.\n");
                 log_message("Rollback completed successfully", LogLevel::INFO);
-                return 0;
             }
-            return 1;
+            else
+            {
+                print_info("Rollback scheduled: previous version will be restored when this command exits.\n");
+                log_message("Rollback scheduled via async helper", LogLevel::INFO);
+            }
+            return 0;
         }
 
         print_info("Checking for updates...\n");
         log_message("Checking for updates (current: " + std::string(Updater::get_current_version()) + ")", LogLevel::INFO);
 
         auto latest = Updater::fetch_latest_release();
+
+        if (latest.version.empty())
+        {
+            print_error("Error: Could not determine the latest release version.\n");
+            log_message("Latest release has empty version tag", LogLevel::ERR);
+            return 1;
+        }
 
         std::string current = Updater::get_current_version();
         int cmp = utils::compare_versions(current, latest.version);
@@ -1311,6 +1324,52 @@ int handle_update_command(const std::vector<std::string> &args)
         if (!latest.changelog.empty())
         {
             std::string changelog = latest.changelog;
+            std::string sanitized;
+            sanitized.reserve(changelog.size());
+            for (size_t i = 0; i < changelog.size(); ++i)
+            {
+                unsigned char c = static_cast<unsigned char>(changelog[i]);
+                if (c == '\x1b')
+                {
+                    if (i + 1 >= changelog.size())
+                        continue;
+                    char next = changelog[i + 1];
+                    if (next == '[')
+                    {
+                        size_t j = i + 2;
+                        while (j < changelog.size() &&
+                               (std::isdigit(static_cast<unsigned char>(changelog[j])) || changelog[j] == ';'))
+                            j++;
+                        if (j < changelog.size() && changelog[j] >= 0x40 && changelog[j] <= 0x7E)
+                        {
+                            i = j;
+                            continue;
+                        }
+                    }
+                    else if (next == ']')
+                    {
+                        size_t j = i + 2;
+                        while (j < changelog.size())
+                        {
+                            if (changelog[j] == '\x07') { i = j; break; }
+                            if (changelog[j] == '\x1b' && j + 1 < changelog.size() && changelog[j + 1] == '\\') { i = j + 1; break; }
+                            j++;
+                        }
+                        if (j >= changelog.size())
+                            i = changelog.size() - 1;
+                        continue;
+                    }
+                    else
+                    {
+                        ++i;
+                        continue;
+                    }
+                }
+                if (c < 0x20 && c != '\t' && c != '\n')
+                    continue;
+                sanitized += static_cast<char>(c);
+            }
+            changelog = sanitized;
             if (changelog.size() > 500)
             {
                 size_t cut = 500;
@@ -1360,7 +1419,8 @@ int handle_update_command(const std::vector<std::string> &args)
 #elif defined(__APPLE__)
         ext = ".zip";
 #endif
-        download_path = (temp_dir / ("torrent_builder_update" + ext)).string();
+        std::random_device rd;
+        download_path = (temp_dir / ("tb_update_" + std::to_string(rd()) + ext)).string();
 
         print_info("Downloading " + latest.version + "...\n");
         log_message("Downloading update " + latest.version + " from: " + *asset_url, LogLevel::INFO);

--- a/src/torrent_builder.cpp
+++ b/src/torrent_builder.cpp
@@ -17,11 +17,15 @@
 #include <ranges>
 #include <stdexcept>
 #include <yaml-cpp/exceptions.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 #include "torrent_inspector.hpp"
 #include "torrent_modifier.hpp"
 #include "torrent_checker.hpp"
 #include "season_pack.hpp"
 #include "output.hpp"
+#include "updater.hpp"
 
 namespace fs = std::filesystem;
 
@@ -1208,6 +1212,238 @@ int handle_batch_command(const std::vector<std::string> &args)
     }
 }
 
+/**
+ * @brief Handle the 'update' subcommand — check for, download, and install newer versions.
+ *
+ * Flags:
+ *   -h,--help   Show help and usage.
+ *   --check     Only check for available updates (no download).
+ *   --yes       Skip confirmation prompt.
+ *   --rollback  Restore previous version from .old backup.
+ *
+ * Returns 0 on success or user cancellation, 1 on error.
+ */
+int handle_update_command(const std::vector<std::string> &args)
+{
+    std::string download_path;
+    try
+    {
+        int argc = static_cast<int>(args.size()) + 1;
+        std::vector<const char *> argv;
+        argv.push_back("torrent-builder");
+        for (const auto &arg : args)
+        {
+            argv.push_back(arg.c_str());
+        }
+
+        cxxopts::Options update_options("torrent-builder update", "Update to the latest version");
+        update_options.add_options()
+            ("h,help", "Show help")
+            ("y,yes", "Skip confirmation prompt")
+            ("check", "Only check for updates (do not download)")
+            ("rollback", "Restore previous version");
+
+        auto result = update_options.parse(argc, argv.data());
+
+        if (result.count("help"))
+        {
+            print_info(update_options.help() + "\n");
+            print_info("\nExamples:\n");
+            print_info("  torrent-builder update\n");
+            print_info("  torrent-builder update --check\n");
+            print_info("  torrent-builder update --yes\n");
+            print_info("  torrent-builder update --rollback\n");
+            return 0;
+        }
+
+        if (result.count("rollback"))
+        {
+            std::string exe_path = Updater::get_exe_path();
+
+            print_info("Rolling back to previous version...\n");
+            log_message("User initiated rollback", LogLevel::INFO);
+
+            if (!prompt_yes_no("Restore previous version?"))
+            {
+                print_info("Rollback cancelled.\n");
+                log_message("Rollback cancelled by user", LogLevel::INFO);
+                return 0;
+            }
+
+            if (Updater::perform_rollback(exe_path))
+            {
+                print_info("Successfully rolled back to previous version.\n");
+                log_message("Rollback completed successfully", LogLevel::INFO);
+                return 0;
+            }
+            return 1;
+        }
+
+        print_info("Checking for updates...\n");
+        log_message("Checking for updates (current: " + std::string(Updater::get_current_version()) + ")", LogLevel::INFO);
+
+        auto latest = Updater::fetch_latest_release();
+
+        std::string current = Updater::get_current_version();
+        int cmp = utils::compare_versions(current, latest.version);
+
+        bool is_dev = current.find("dev") != std::string::npos;
+
+        if (cmp >= 0 && !is_dev)
+        {
+            print_info("Already up to date: " + current + "\n");
+            log_message("Already up to date: " + current, LogLevel::INFO);
+            return 0;
+        }
+
+        if (cmp > 0 && is_dev)
+        {
+            print_info("Current dev version (" + current + ") is newer than latest release (" + latest.version + ").\n");
+            log_message("Dev build ahead of latest release: " + current + " > " + latest.version, LogLevel::INFO);
+            return 0;
+        }
+
+        log_message("Update available: " + current + " -> " + latest.version, LogLevel::INFO);
+
+        print_info("Current version:  " + current + "\n");
+        print_info("Latest version:   " + latest.version + "\n");
+
+        if (!latest.changelog.empty())
+        {
+            std::string changelog = latest.changelog;
+            if (changelog.size() > 500)
+            {
+                size_t cut = 500;
+                while (cut > 0 && (static_cast<unsigned char>(changelog[cut]) & 0xC0) == 0x80)
+                    --cut;
+                changelog = changelog.substr(0, cut) + "...";
+            }
+            print_info("\nChangelog:\n" + changelog + "\n\n");
+        }
+
+        if (result.count("check"))
+        {
+            print_info("Update available. Run 'torrent-builder update' to install.\n");
+            log_message("Check-only mode: update available (" + latest.version + ")", LogLevel::INFO);
+            return 0;
+        }
+
+        auto platform = Updater::get_platform_info();
+        print_info("Platform: " + platform.os + "/" + platform.arch + "\n");
+
+        auto asset_url = Updater::find_matching_asset_from_json(latest.release_json, platform);
+        if (!asset_url)
+        {
+            log_message("No matching asset for " + platform.os + "/" + platform.arch, LogLevel::ERR);
+            print_error("Error: No matching binary found for " + platform.os + "/" + platform.arch + "\n");
+            return 1;
+        }
+
+        latest.asset_size = Updater::get_asset_size(latest.release_json, *asset_url);
+
+        if (!result.count("yes"))
+        {
+            if (!prompt_yes_no("Download and install version " + latest.version + "?"))
+            {
+                print_info("Update cancelled.\n");
+                log_message("Update cancelled by user for version " + latest.version, LogLevel::INFO);
+                return 0;
+            }
+        }
+
+        std::string exe_path = Updater::get_exe_path();
+
+        fs::path temp_dir = fs::temp_directory_path();
+        std::string ext = "";
+#ifdef _WIN32
+        ext = ".exe";
+#elif defined(__APPLE__)
+        ext = ".zip";
+#endif
+        download_path = (temp_dir / ("torrent_builder_update" + ext)).string();
+
+        print_info("Downloading " + latest.version + "...\n");
+        log_message("Downloading update " + latest.version + " from: " + *asset_url, LogLevel::INFO);
+
+        if (!Updater::download_asset(*asset_url, download_path, latest.asset_size))
+        {
+            log_message("Download failed for: " + *asset_url, LogLevel::ERR);
+            print_error("Error: Failed to download update.\n");
+            try { fs::remove(download_path); } catch (...) {}
+            return 1;
+        }
+
+        auto checksums = Updater::fetch_checksums(latest.release_json);
+        bool has_checksum = false;
+        if (checksums)
+        {
+            std::string asset_name = fs::path(*asset_url).filename().string();
+            auto expected_hash = Updater::lookup_checksum(*checksums, asset_name);
+            if (expected_hash)
+            {
+                has_checksum = true;
+                print_info("Verifying checksum...\n");
+                log_message("Verifying checksum for: " + download_path, LogLevel::INFO);
+                if (!Updater::verify_checksum(download_path, *expected_hash))
+                {
+                    log_message("Checksum verification failed for: " + download_path, LogLevel::ERR);
+                    print_error("Error: Checksum verification failed. Download may be corrupted.\n");
+                    try { fs::remove(download_path); } catch (...) {}
+                    return 1;
+                }
+                print_info("Checksum verified.\n");
+            }
+            else
+            {
+                log_message("No checksum found for asset: " + asset_name, LogLevel::WARNING);
+            }
+        }
+        else
+        {
+            log_message("No checksums.txt found in release, skipping verification", LogLevel::WARNING);
+        }
+
+        if (!has_checksum)
+        {
+            if (!Updater::is_valid_binary(download_path))
+            {
+                log_message("Downloaded file is not a valid binary: " + download_path, LogLevel::ERR);
+                print_error("Error: Downloaded file is not a valid binary. The download may be corrupted.\n");
+                try { fs::remove(download_path); } catch (...) {}
+                return 1;
+            }
+            log_message("No checksum available, validated binary format instead", LogLevel::WARNING);
+        }
+
+        print_info("Installing update...\n");
+        log_message("Installing update from: " + download_path + " to: " + exe_path, LogLevel::INFO);
+
+        UpdateResult update_result = Updater::perform_update(download_path, exe_path);
+
+        if (update_result == UpdateResult::Success)
+        {
+            try { fs::remove(download_path); } catch (...) {}
+            print_info("Successfully updated to version " + latest.version + "!\n");
+            log_message("Successfully updated to version " + latest.version, LogLevel::INFO);
+        }
+        else
+        {
+            print_info("Update scheduled: version " + latest.version +
+                           " will be installed when this command exits.\n");
+            log_message("Update scheduled via async helper for version " + latest.version, LogLevel::INFO);
+        }
+        return 0;
+    }
+    catch (const std::exception &e)
+    {
+        log_message("Update error: " + std::string(e.what()), LogLevel::ERR);
+        print_error(std::string("Error: ") + e.what() + "\n");
+        try { fs::remove(download_path); } catch (...) {}
+        return 1;
+    }
+}
+
+#ifndef TORRENT_BUILDER_EXCLUDE_MAIN
 int main(int argc, char *argv[])
 {
     // Check for subcommands
@@ -1249,6 +1485,16 @@ int main(int argc, char *argv[])
             args.push_back(argv[i]);
         }
         return handle_batch_command(args);
+    }
+
+    if (argc >= 2 && std::string(argv[1]) == "update")
+    {
+        std::vector<std::string> args;
+        for (int i = 2; i < argc; ++i)
+        {
+            args.push_back(argv[i]);
+        }
+        return handle_update_command(args);
     }
 
     try
@@ -1436,3 +1682,4 @@ int main(int argc, char *argv[])
 
     return 0;
 }
+#endif

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -1,0 +1,970 @@
+#include "updater.hpp"
+#include "utils.hpp"
+#include "logger.hpp"
+#include "output.hpp"
+#include "version.hpp"
+#include <nlohmann/json.hpp>
+#include <filesystem>
+#include <cstdlib>
+#include <cstdint>
+#include <cstdio>
+#include <sstream>
+#include <array>
+#include <stdexcept>
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <vector>
+#include <openssl/evp.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <unistd.h>
+#include <sys/stat.h>
+#include <mach-o/dyld.h>
+#else
+#include <unistd.h>
+#include <sys/stat.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace
+{
+Updater::CurlExecutor g_curl_executor;
+Updater::FileDownloader g_file_downloader;
+Updater::ExePathProvider g_exe_path_provider;
+Updater::BinaryValidator g_binary_validator;
+std::string g_current_version_override;
+std::optional<std::string> g_curl_path_cache;
+
+std::string escape_batch_path(const std::string &path)
+{
+    std::string escaped;
+    escaped.reserve(path.size() * 2);
+    for (char c : path)
+    {
+        if (c == '"')
+            escaped += "\"\"";
+        else if (c == '%')
+            escaped += "%%";
+        else
+            escaped += c;
+    }
+    return escaped;
+}
+
+std::string escape_shell_arg(const std::string &arg)
+{
+    std::string escaped;
+    escaped.reserve(arg.size() + 2);
+#ifdef _WIN32
+    escaped += "\"";
+    for (char c : arg)
+    {
+        if (c == '"')
+            escaped += "\"\"";
+        else
+            escaped += c;
+    }
+    escaped += "\"";
+#else
+    escaped += "'";
+    for (char c : arg)
+    {
+        if (c == '\'')
+            escaped += "'\\''";
+        else
+            escaped += c;
+    }
+    escaped += "'";
+#endif
+    return escaped;
+}
+
+std::string compute_sha256(const std::string &filepath)
+{
+    std::ifstream file(filepath, std::ios::binary);
+    if (!file)
+    {
+        log_message("SHA-256: failed to open file: " + filepath, LogLevel::WARNING);
+        return "";
+    }
+
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx)
+    {
+        log_message("SHA-256: failed to create EVP context", LogLevel::WARNING);
+        return "";
+    }
+
+    if (EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr) != 1)
+    {
+        EVP_MD_CTX_free(ctx);
+        log_message("SHA-256: EVP_DigestInit_ex failed", LogLevel::WARNING);
+        return "";
+    }
+
+    char buf[8192];
+    while (file.read(buf, sizeof(buf)))
+    {
+        if (EVP_DigestUpdate(ctx, buf, static_cast<size_t>(file.gcount())) != 1)
+        {
+            EVP_MD_CTX_free(ctx);
+            log_message("SHA-256: EVP_DigestUpdate failed", LogLevel::WARNING);
+            return "";
+        }
+    }
+    if (file.gcount() > 0)
+    {
+        if (EVP_DigestUpdate(ctx, buf, static_cast<size_t>(file.gcount())) != 1)
+        {
+            EVP_MD_CTX_free(ctx);
+            log_message("SHA-256: EVP_DigestUpdate (tail) failed", LogLevel::WARNING);
+            return "";
+        }
+    }
+
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int digest_len = 0;
+    if (EVP_DigestFinal_ex(ctx, digest, &digest_len) != 1)
+    {
+        EVP_MD_CTX_free(ctx);
+        log_message("SHA-256: EVP_DigestFinal_ex failed", LogLevel::WARNING);
+        return "";
+    }
+    EVP_MD_CTX_free(ctx);
+
+    std::string hash;
+    hash.reserve(digest_len * 2);
+    for (unsigned int i = 0; i < digest_len; ++i)
+    {
+        char hex[3];
+        std::snprintf(hex, sizeof(hex), "%02x", digest[i]);
+        hash += hex;
+    }
+    return hash;
+}
+
+nlohmann::json fetch_release_json()
+{
+    std::string url = "https://api.github.com/repos/cantalupo555/torrent-builder/releases/latest";
+
+    std::string response;
+    try
+    {
+        response = Updater::execute_curl(url, {"-H", "Accept: application/vnd.github+json"});
+    }
+    catch (const std::exception &e)
+    {
+        if (std::string(e.what()).find("rate limit") != std::string::npos)
+        {
+            throw std::runtime_error("GitHub API rate limit exceeded. Try again later or set GITHUB_TOKEN env variable.");
+        }
+        throw std::runtime_error(std::string("Failed to fetch release info: ") + e.what());
+    }
+
+    nlohmann::json j;
+    try
+    {
+        j = nlohmann::json::parse(response);
+    }
+    catch (const nlohmann::json::parse_error &)
+    {
+        throw std::runtime_error("Failed to parse GitHub API response");
+    }
+
+    if (j.contains("message") && j.contains("status"))
+    {
+        std::string msg = j["message"].get<std::string>();
+        if (msg.find("rate limit") != std::string::npos)
+        {
+            throw std::runtime_error("GitHub API rate limit exceeded. Try again later.");
+        }
+        throw std::runtime_error("GitHub API error: " + msg);
+    }
+
+    return j;
+}
+
+bool ends_with(const std::string &str, const std::string &suffix)
+{
+    if (suffix.size() > str.size())
+        return false;
+    return str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+}
+
+void Updater::set_curl_executor_for_testing(CurlExecutor executor)
+{
+    g_curl_executor = std::move(executor);
+}
+
+void Updater::set_file_downloader_for_testing(FileDownloader downloader)
+{
+    g_file_downloader = std::move(downloader);
+}
+
+void Updater::set_exe_path_provider_for_testing(ExePathProvider provider)
+{
+    g_exe_path_provider = std::move(provider);
+}
+
+void Updater::set_current_version_for_testing(const std::string &version)
+{
+    g_current_version_override = version;
+}
+
+void Updater::set_binary_validator_for_testing(BinaryValidator validator)
+{
+    g_binary_validator = std::move(validator);
+}
+
+void Updater::reset_test_overrides()
+{
+    g_curl_executor = nullptr;
+    g_file_downloader = nullptr;
+    g_exe_path_provider = nullptr;
+    g_binary_validator = nullptr;
+    g_current_version_override.clear();
+    g_curl_path_cache.reset();
+}
+
+PlatformInfo Updater::get_platform_info()
+{
+    PlatformInfo info;
+#if defined(_WIN32)
+    info.os = "windows";
+#elif defined(__APPLE__)
+    info.os = "macos";
+#elif defined(__linux__)
+    info.os = "linux";
+#else
+    info.os = "unknown";
+#endif
+
+#if defined(__x86_64__) || defined(_M_X64)
+    info.arch = "amd64";
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    info.arch = "arm64";
+#else
+    info.arch = "unknown";
+#endif
+    return info;
+}
+
+std::string Updater::get_current_version()
+{
+    if (!g_current_version_override.empty())
+        return g_current_version_override;
+    return TORRENT_BUILDER_VERSION;
+}
+
+std::string Updater::get_exe_path()
+{
+    if (g_exe_path_provider)
+        return g_exe_path_provider();
+
+    try
+    {
+#ifdef _WIN32
+        std::array<char, 4096> buf;
+        DWORD len = GetModuleFileNameA(NULL, buf.data(), static_cast<DWORD>(buf.size()));
+        if (len > 0 && len < buf.size())
+        {
+            return std::string(buf.data(), len);
+        }
+#elif defined(__linux__)
+        return fs::canonical("/proc/self/exe").string();
+#elif defined(__APPLE__)
+        std::array<char, 4096> buf;
+        uint32_t size = static_cast<uint32_t>(buf.size());
+        std::string result;
+        if (_NSGetExecutablePath(buf.data(), &size) == 0)
+        {
+            result = std::string(buf.data());
+        }
+        else if (size > static_cast<uint32_t>(buf.size()))
+        {
+            std::vector<char> big_buf(size);
+            if (_NSGetExecutablePath(big_buf.data(), &size) == 0)
+            {
+                result = std::string(big_buf.data());
+            }
+        }
+        if (!result.empty())
+            return result;
+#endif
+    }
+    catch (const fs::filesystem_error &)
+    {
+    }
+
+#ifdef __linux__
+    std::array<char, 4096> buf;
+    ssize_t len = readlink("/proc/self/exe", buf.data(), buf.size());
+    if (len > 0)
+        return std::string(buf.data(), static_cast<size_t>(len));
+#endif
+
+    return "torrent_builder";
+}
+
+std::string Updater::find_curl_executable()
+{
+    if (g_curl_path_cache.has_value())
+        return *g_curl_path_cache;
+
+    auto check = [](const std::string &path) -> bool
+    {
+        return fs::exists(path);
+    };
+
+#ifdef _WIN32
+    std::vector<std::string> candidates = {
+        "C:\\Windows\\System32\\curl.exe",
+        "C:\\Windows\\SysWOW64\\curl.exe"};
+    const char *path_env = std::getenv("PATH");
+    if (path_env)
+    {
+        std::istringstream iss(path_env);
+        std::string dir;
+        while (std::getline(iss, dir, ';'))
+        {
+            candidates.push_back(dir + "\\curl.exe");
+        }
+    }
+#else
+    std::vector<std::string> candidates = {
+        "/usr/bin/curl",
+        "/usr/local/bin/curl",
+        "/opt/homebrew/bin/curl"};
+    const char *path_env = std::getenv("PATH");
+    if (path_env)
+    {
+        std::istringstream iss(path_env);
+        std::string dir;
+        while (std::getline(iss, dir, ':'))
+        {
+            candidates.push_back(dir + "/curl");
+        }
+    }
+#endif
+
+    for (const auto &c : candidates)
+    {
+        if (check(c))
+        {
+            g_curl_path_cache = c;
+            return c;
+        }
+    }
+
+    g_curl_path_cache = "curl";
+    return "curl";
+}
+
+bool Updater::is_safe_url(const std::string &url)
+{
+    if (url.size() < 9 || url.substr(0, 8) != "https://")
+        return false;
+
+    static const std::string safe_chars =
+        "abcdefghijklmnopqrstuvwxyz"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "0123456789"
+        ":/.-_~?=%+@&";
+    if (url.find_first_not_of(safe_chars) != std::string::npos)
+        return false;
+
+    for (size_t i = 0; i < url.size(); ++i)
+    {
+        if (url[i] != '%')
+            continue;
+        if (i + 2 >= url.size())
+            return false;
+        if (!std::isxdigit(static_cast<unsigned char>(url[i + 1])) ||
+            !std::isxdigit(static_cast<unsigned char>(url[i + 2])))
+            return false;
+        i += 2;
+    }
+
+    return true;
+}
+
+bool Updater::is_valid_binary(const std::string &filepath)
+{
+    if (g_binary_validator)
+        return g_binary_validator(filepath);
+
+    std::ifstream file(filepath, std::ios::binary);
+    if (!file)
+        return false;
+
+    char magic[4] = {};
+    if (!file.read(magic, 4))
+        return false;
+
+    if (magic[0] == 0x7f && magic[1] == 'E' && magic[2] == 'L' && magic[3] == 'F')
+        return true;
+
+    if (magic[0] == 'M' && magic[1] == 'Z')
+        return true;
+
+    uint32_t m = static_cast<unsigned char>(magic[0])
+        | (static_cast<unsigned char>(magic[1]) << 8)
+        | (static_cast<unsigned char>(magic[2]) << 16)
+        | (static_cast<unsigned char>(magic[3]) << 24);
+    if (m == 0xfeedface || m == 0xcefaedfe
+        || m == 0xfeedfacf || m == 0xcffaedfe)
+        return true;
+
+    return false;
+}
+
+std::string Updater::build_script_launch_cmd()
+{
+    return "cmd /c start \"\" /b \"%TB_LAUNCH_SCRIPT%\"";
+}
+
+std::string Updater::execute_curl(const std::string &url, const std::vector<std::string> &extra_args)
+{
+    if (g_curl_executor)
+        return g_curl_executor(url, extra_args);
+
+    if (!is_safe_url(url))
+    {
+        log_message("Rejected unsafe URL: " + url, LogLevel::ERR);
+        throw std::runtime_error("Unsafe URL rejected: " + url);
+    }
+
+    std::string curl_path = find_curl_executable();
+    std::string cmd = escape_shell_arg(curl_path) + " -s -L --proto =https";
+
+    for (const auto &arg : extra_args)
+    {
+        cmd += " " + escape_shell_arg(arg);
+    }
+
+    cmd += " " + escape_shell_arg(url);
+
+#ifdef _WIN32
+    cmd += " 2>NUL";
+#endif
+
+    log_message("Executing curl request to: " + url, LogLevel::INFO);
+
+    std::array<char, 4096> buffer;
+    std::string output;
+    FILE *pipe =
+#ifdef _WIN32
+        _popen(cmd.c_str(), "r");
+#else
+        popen(cmd.c_str(), "r");
+#endif
+
+    if (!pipe)
+    {
+        log_message("Failed to execute curl for URL: " + url, LogLevel::ERR);
+        throw std::runtime_error("Failed to execute curl");
+    }
+
+    while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr)
+    {
+        output += buffer.data();
+    }
+
+#ifdef _WIN32
+    int status = _pclose(pipe);
+#else
+    int status = pclose(pipe);
+#endif
+
+    if (status != 0)
+    {
+        log_message("curl request failed with status " + std::to_string(status) + " for URL: " + url, LogLevel::ERR);
+        throw std::runtime_error("curl request failed with status " + std::to_string(status) + " for URL: " + url);
+    }
+
+    return output;
+}
+
+UpdateInfo Updater::fetch_latest_release()
+{
+    nlohmann::json j = fetch_release_json();
+
+    UpdateInfo info;
+    info.version = j.value("tag_name", "");
+    if (!info.version.empty() && (info.version[0] == 'v' || info.version[0] == 'V'))
+    {
+        info.version = info.version.substr(1);
+    }
+
+    info.changelog = j.value("body", "");
+    info.release_json = j;
+
+    return info;
+}
+
+std::optional<std::string> Updater::find_matching_asset(const std::string &release_json, const PlatformInfo &platform)
+{
+    nlohmann::json j;
+    try
+    {
+        j = nlohmann::json::parse(release_json);
+    }
+    catch (const nlohmann::json::parse_error &)
+    {
+        return std::nullopt;
+    }
+
+    return find_matching_asset_from_json(j, platform);
+}
+
+std::optional<std::string> Updater::find_matching_asset_from_json(const nlohmann::json &j, const PlatformInfo &platform)
+{
+    if (!j.contains("assets") || !j["assets"].is_array())
+    {
+        return std::nullopt;
+    }
+
+    std::string suffix = "_" + platform.os + "_" + platform.arch;
+    if (platform.os == "windows")
+        suffix += ".exe";
+    else if (platform.os == "macos")
+        suffix += ".zip";
+
+    for (const auto &asset : j["assets"])
+    {
+        std::string name = asset.value("name", "");
+        if (ends_with(name, suffix))
+        {
+            return asset.value("browser_download_url", "");
+        }
+    }
+
+    return std::nullopt;
+}
+
+int64_t Updater::get_asset_size(const nlohmann::json &release_json, const std::string &asset_url)
+{
+    if (!release_json.contains("assets") || !release_json["assets"].is_array())
+        return 0;
+
+    for (const auto &asset : release_json["assets"])
+    {
+        if (asset.value("browser_download_url", "") == asset_url)
+        {
+            return asset.value("size", int64_t(0));
+        }
+    }
+    return 0;
+}
+
+std::optional<std::string> Updater::fetch_checksums()
+{
+    nlohmann::json j = fetch_release_json();
+    return fetch_checksums(j);
+}
+
+std::optional<std::string> Updater::fetch_checksums(const nlohmann::json &release_json)
+{
+    if (!release_json.contains("assets") || !release_json["assets"].is_array())
+    {
+        return std::nullopt;
+    }
+
+    for (const auto &asset : release_json["assets"])
+    {
+        std::string name = asset.value("name", "");
+        if (name == "checksums.txt")
+        {
+            std::string download_url = asset.value("browser_download_url", "");
+            if (download_url.empty())
+                return std::nullopt;
+
+            try
+            {
+                return execute_curl(download_url);
+            }
+            catch (const std::exception &e)
+            {
+                log_message(std::string("Failed to fetch checksums: ") + e.what(), LogLevel::WARNING);
+                return std::nullopt;
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> Updater::lookup_checksum(const std::string &checksums_content, const std::string &asset_name)
+{
+    std::istringstream stream(checksums_content);
+    std::string line;
+    while (std::getline(stream, line))
+    {
+        auto space_pos = line.find(' ');
+        if (space_pos == std::string::npos)
+            continue;
+
+        std::string hash = line.substr(0, space_pos);
+        std::string name = line.substr(space_pos + 1);
+        if (!name.empty() && name[0] == '*')
+            name.erase(0, 1);
+        name.erase(0, name.find_first_not_of(" \t"));
+        name.erase(name.find_last_not_of(" \t\r\n") + 1);
+
+        if (name == asset_name)
+        {
+            std::transform(hash.begin(), hash.end(), hash.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            return hash;
+        }
+    }
+    return std::nullopt;
+}
+
+bool Updater::download_asset(const std::string &url, const std::string &dest_path, int64_t expected_size)
+{
+    if (g_file_downloader)
+        return g_file_downloader(url, dest_path, expected_size);
+
+    if (!is_safe_url(url))
+    {
+        log_message("Rejected unsafe download URL: " + url, LogLevel::ERR);
+        return false;
+    }
+
+    std::string curl_path = find_curl_executable();
+    std::string cmd = escape_shell_arg(curl_path) + " -s -L --fail --proto =https -o " + escape_shell_arg(dest_path);
+
+    if (expected_size > 0)
+    {
+        cmd += " --max-filesize " + std::to_string(expected_size + 1024 * 1024);
+    }
+
+    cmd += " " + escape_shell_arg(url);
+
+#ifdef _WIN32
+    cmd += " 2>NUL";
+#endif
+
+    log_message("Downloading asset from: " + url + " to: " + dest_path, LogLevel::INFO);
+
+    int status = std::system(cmd.c_str());
+    if (status != 0)
+    {
+        log_message("Download failed with status " + std::to_string(status) + " for URL: " + url, LogLevel::ERR);
+        return false;
+    }
+
+    return fs::exists(dest_path) && fs::file_size(dest_path) > 0;
+}
+
+bool Updater::verify_checksum(const std::string &filepath, const std::string &expected_hash)
+{
+    std::string actual = compute_sha256(filepath);
+    if (actual.empty())
+    {
+        log_message("Could not compute SHA-256 for: " + filepath, LogLevel::WARNING);
+        return false;
+    }
+
+    std::string expected = expected_hash;
+    std::transform(expected.begin(), expected.end(), expected.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
+    if (actual != expected)
+    {
+        log_message("Checksum mismatch for " + filepath + ": expected " + expected + " got " + actual, LogLevel::ERR);
+        return false;
+    }
+
+    log_message("Checksum verified for: " + filepath, LogLevel::INFO);
+    return true;
+}
+
+std::string Updater::get_old_binary_path(const std::string &current_path)
+{
+    return current_path + ".old";
+}
+
+bool Updater::make_executable(const std::string &path)
+{
+#ifndef _WIN32
+    try
+    {
+        fs::permissions(path, fs::perms::owner_all | fs::perms::group_read | fs::perms::group_exec | fs::perms::others_read | fs::perms::others_exec, fs::perm_options::replace);
+        return true;
+    }
+    catch (const fs::filesystem_error &)
+    {
+        return false;
+    }
+#else
+    return true;
+#endif
+}
+
+bool Updater::extract_macos_zip(const std::string &zip_path, const std::string &dest_dir)
+{
+    std::string cmd = "unzip -o " + escape_shell_arg(zip_path) + " -d " + escape_shell_arg(dest_dir) + " 2>/dev/null";
+    int status = std::system(cmd.c_str());
+    if (status != 0)
+    {
+        return false;
+    }
+
+    fs::path extracted = fs::path(dest_dir) / "torrent_builder";
+    if (!fs::exists(extracted))
+    {
+        return false;
+    }
+
+    return make_executable(extracted.string());
+}
+
+UpdateResult Updater::perform_update(const std::string &new_binary_path, const std::string &current_binary_path)
+{
+    log_message("Starting update: replacing " + current_binary_path + " with " + new_binary_path, LogLevel::INFO);
+    std::string old_path = get_old_binary_path(current_binary_path);
+    std::string new_path = new_binary_path;
+
+    if (!fs::exists(new_path))
+    {
+        throw std::runtime_error("New binary not found: " + new_path);
+    }
+
+    if (fs::exists(old_path))
+    {
+        try
+        {
+            fs::remove(old_path);
+        }
+        catch (const fs::filesystem_error &)
+        {
+            print_error("Warning: Could not remove previous backup file: " + old_path + "\n");
+        }
+    }
+
+#ifdef __APPLE__
+    if (new_path.size() >= 4 && new_path.compare(new_path.size() - 4, 4, ".zip") == 0)
+    {
+        fs::path temp_dir = fs::path(current_binary_path).parent_path() / ".torrent_builder_update";
+        fs::create_directories(temp_dir);
+
+        if (!extract_macos_zip(new_path, temp_dir.string()))
+        {
+            fs::remove_all(temp_dir);
+            throw std::runtime_error("Failed to extract macOS zip archive");
+        }
+
+        new_path = (temp_dir / "torrent_builder").string();
+    }
+#endif
+
+    if (!make_executable(new_path))
+    {
+        throw std::runtime_error("Failed to set executable permissions on new binary");
+    }
+
+#ifdef _WIN32
+    try
+    {
+        fs::rename(current_binary_path, old_path);
+        fs::rename(new_path, current_binary_path);
+    }
+    catch (const fs::filesystem_error &)
+    {
+        std::string esc_current = escape_batch_path(current_binary_path);
+        std::string esc_old = escape_batch_path(old_path);
+        std::string esc_new = escape_batch_path(new_path);
+
+        std::string script_path = current_binary_path + ".update.bat";
+        {
+            std::ofstream script(script_path);
+            if (!script)
+            {
+                throw std::runtime_error("Failed to create update script");
+            }
+            script << "@echo off\n";
+            script << "timeout /t 2 /nobreak >nul\n";
+            script << "move /y \"" << esc_current << "\" \"" << esc_old << "\"\n";
+            script << "move /y \"" << esc_new << "\" \"" << esc_current << "\"\n";
+            script << "del \"%~f0\"\n";
+        }
+
+        SetEnvironmentVariableA("TB_LAUNCH_SCRIPT", script_path.c_str());
+        std::string cmd = build_script_launch_cmd();
+        int status = std::system(cmd.c_str());
+        SetEnvironmentVariableA("TB_LAUNCH_SCRIPT", nullptr);
+        if (status != 0)
+        {
+            fs::remove(script_path);
+            throw std::runtime_error("Failed to launch update script");
+        }
+        log_message("Update scheduled via batch script: " + script_path, LogLevel::INFO);
+        return UpdateResult::PendingRestart;
+    }
+#else
+    try
+    {
+        fs::rename(current_binary_path, old_path);
+    }
+    catch (const fs::filesystem_error &e)
+    {
+        throw std::runtime_error("Failed to backup current binary: " + std::string(e.what()));
+    }
+
+    try
+    {
+        std::error_code rename_ec;
+        fs::rename(new_path, current_binary_path, rename_ec);
+        if (rename_ec)
+        {
+            if (rename_ec == std::errc::cross_device_link)
+            {
+                fs::copy_file(new_path, current_binary_path, fs::copy_options::overwrite_existing);
+                if (!make_executable(current_binary_path))
+                {
+                    throw fs::filesystem_error("failed to set executable permissions after cross-device copy",
+                                               current_binary_path, new_path,
+                                               std::make_error_code(std::errc::operation_not_permitted));
+                }
+                fs::remove(new_path);
+            }
+            else
+            {
+                throw fs::filesystem_error("rename failed", new_path, current_binary_path, rename_ec);
+            }
+        }
+    }
+    catch (const fs::filesystem_error &e)
+    {
+#ifdef __APPLE__
+        try
+        {
+            fs::path temp_dir = fs::path(current_binary_path).parent_path() / ".torrent_builder_update";
+            if (fs::exists(temp_dir))
+                fs::remove_all(temp_dir);
+        }
+        catch (const fs::filesystem_error &)
+        {
+        }
+#endif
+        try
+        {
+            fs::rename(old_path, current_binary_path);
+        }
+        catch (const fs::filesystem_error &)
+        {
+            throw std::runtime_error(
+                "Failed to replace binary and rollback also failed. "
+                "The binary may be in an inconsistent state. "
+                "Original error: " + std::string(e.what()));
+        }
+        throw std::runtime_error("Failed to replace binary (rolled back): " + std::string(e.what()));
+    }
+#endif
+
+#ifdef __APPLE__
+    try
+    {
+        fs::path temp_dir = fs::path(current_binary_path).parent_path() / ".torrent_builder_update";
+        if (fs::exists(temp_dir))
+        {
+            fs::remove_all(temp_dir);
+        }
+    }
+    catch (const fs::filesystem_error &)
+    {
+    }
+#endif
+
+    return UpdateResult::Success;
+}
+
+bool Updater::perform_rollback(const std::string &current_binary_path)
+{
+    log_message("Starting rollback for: " + current_binary_path, LogLevel::INFO);
+    std::string old_path = get_old_binary_path(current_binary_path);
+
+    if (!fs::exists(old_path))
+    {
+        throw std::runtime_error("No previous version found to rollback to (" + old_path + " does not exist)");
+    }
+
+#ifdef _WIN32
+    try
+    {
+        fs::rename(old_path, current_binary_path);
+        return true;
+    }
+    catch (const fs::filesystem_error &)
+    {
+    }
+
+    std::string esc_current = escape_batch_path(current_binary_path);
+    std::string esc_old = escape_batch_path(old_path);
+
+    std::string script_path = current_binary_path + ".rollback.bat";
+    {
+        std::ofstream script(script_path);
+        if (!script)
+        {
+            throw std::runtime_error("Failed to create rollback script");
+        }
+        script << "@echo off\n";
+        script << "timeout /t 2 /nobreak >nul\n";
+        script << "move /y \"" << esc_old << "\" \"" << esc_current << "\"\n";
+        script << "del \"%~f0\"\n";
+    }
+
+    SetEnvironmentVariableA("TB_LAUNCH_SCRIPT", script_path.c_str());
+    std::string cmd = build_script_launch_cmd();
+    int status = std::system(cmd.c_str());
+    SetEnvironmentVariableA("TB_LAUNCH_SCRIPT", nullptr);
+    if (status != 0)
+    {
+        fs::remove(script_path);
+        throw std::runtime_error("Failed to launch rollback script");
+    }
+#else
+    std::string temp_path = current_binary_path + ".rbtmp";
+    try
+    {
+        fs::rename(current_binary_path, temp_path);
+    }
+    catch (const fs::filesystem_error &e)
+    {
+        throw std::runtime_error("Rollback failed: " + std::string(e.what()));
+    }
+
+    try
+    {
+        fs::rename(old_path, current_binary_path);
+    }
+    catch (const fs::filesystem_error &e)
+    {
+        try { fs::rename(temp_path, current_binary_path); }
+        catch (const fs::filesystem_error &restore_err)
+        {
+            log_message("Rollback restore also failed: " + std::string(restore_err.what()) +
+                        " — binary may be missing at " + current_binary_path, LogLevel::ERR);
+        }
+        throw std::runtime_error("Rollback failed: " + std::string(e.what()));
+    }
+
+    try
+    {
+        fs::remove(temp_path);
+    }
+    catch (const fs::filesystem_error &)
+    {
+    }
+#endif
+
+    return true;
+}

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <fstream>
 #include <vector>
 #include <openssl/evp.h>
@@ -154,7 +155,17 @@ nlohmann::json fetch_release_json()
     std::string response;
     try
     {
-        response = Updater::execute_curl(url, {"-H", "Accept: application/vnd.github+json"});
+        std::vector<std::string> args = {"-H", "Accept: application/vnd.github+json"};
+        if (const char *tok = std::getenv("GITHUB_TOKEN"))
+        {
+            if (tok[0] != '\0')
+            {
+                args.push_back("-H");
+                args.push_back(std::string("Authorization: Bearer ") + tok);
+                log_message("Using GITHUB_TOKEN for authenticated API request", LogLevel::INFO);
+            }
+        }
+        response = Updater::execute_curl(url, args);
     }
     catch (const std::exception &e)
     {
@@ -175,7 +186,7 @@ nlohmann::json fetch_release_json()
         throw std::runtime_error("Failed to parse GitHub API response");
     }
 
-    if (j.contains("message") && j.contains("status"))
+    if (j.contains("message") && !j.contains("tag_name"))
     {
         std::string msg = j["message"].get<std::string>();
         if (msg.find("rate limit") != std::string::npos)
@@ -294,7 +305,13 @@ std::string Updater::get_exe_path()
             }
         }
         if (!result.empty())
+        {
+            std::error_code ec;
+            fs::path canonical_path = fs::canonical(result, ec);
+            if (!ec)
+                return canonical_path.string();
             return result;
+        }
 #endif
     }
     catch (const fs::filesystem_error &)
@@ -361,6 +378,7 @@ std::string Updater::find_curl_executable()
         }
     }
 
+    log_message("curl not found in common paths, falling back to PATH lookup", LogLevel::WARNING);
     g_curl_path_cache = "curl";
     return "curl";
 }
@@ -412,6 +430,12 @@ bool Updater::is_valid_binary(const std::string &filepath)
     if (magic[0] == 'M' && magic[1] == 'Z')
         return true;
 
+#ifdef __APPLE__
+    static constexpr unsigned char ZIP_MAGIC[] = {0x50, 0x4b, 0x03, 0x04};
+    if (memcmp(magic, ZIP_MAGIC, 4) == 0)
+        return true;
+#endif
+
     uint32_t m = static_cast<unsigned char>(magic[0])
         | (static_cast<unsigned char>(magic[1]) << 8)
         | (static_cast<unsigned char>(magic[2]) << 16)
@@ -440,7 +464,7 @@ std::string Updater::execute_curl(const std::string &url, const std::vector<std:
     }
 
     std::string curl_path = find_curl_executable();
-    std::string cmd = escape_shell_arg(curl_path) + " -s -L --proto =https";
+    std::string cmd = escape_shell_arg(curl_path) + " -s -S -L --connect-timeout 30 --max-time 300 --proto =https";
 
     for (const auto &arg : extra_args)
     {
@@ -540,7 +564,9 @@ std::optional<std::string> Updater::find_matching_asset_from_json(const nlohmann
         std::string name = asset.value("name", "");
         if (ends_with(name, suffix))
         {
-            return asset.value("browser_download_url", "");
+            std::string url = asset.value("browser_download_url", "");
+            if (!url.empty())
+                return url;
         }
     }
 
@@ -638,7 +664,7 @@ bool Updater::download_asset(const std::string &url, const std::string &dest_pat
     }
 
     std::string curl_path = find_curl_executable();
-    std::string cmd = escape_shell_arg(curl_path) + " -s -L --fail --proto =https -o " + escape_shell_arg(dest_path);
+    std::string cmd = escape_shell_arg(curl_path) + " -s -S -L --fail --connect-timeout 30 --max-time 300 --proto =https -o " + escape_shell_arg(dest_path);
 
     if (expected_size > 0)
     {
@@ -660,7 +686,33 @@ bool Updater::download_asset(const std::string &url, const std::string &dest_pat
         return false;
     }
 
-    return fs::exists(dest_path) && fs::file_size(dest_path) > 0;
+    return verify_downloaded_file(dest_path, expected_size);
+}
+
+bool Updater::verify_downloaded_file(const std::string &path, int64_t expected_size)
+{
+    std::error_code ec;
+    auto size = fs::file_size(path, ec);
+    if (ec)
+    {
+        log_message("Downloaded file is missing or inaccessible: " + path + " (" + ec.message() + ")", LogLevel::ERR);
+        return false;
+    }
+    if (size == 0)
+    {
+        log_message("Downloaded file is empty: " + path, LogLevel::ERR);
+        return false;
+    }
+
+    if (expected_size > 0 && static_cast<int64_t>(size) != expected_size)
+    {
+        log_message("Downloaded file size mismatch: expected " + std::to_string(expected_size) +
+                        " got " + std::to_string(size),
+                    LogLevel::ERR);
+        return false;
+    }
+
+    return true;
 }
 
 bool Updater::verify_checksum(const std::string &filepath, const std::string &expected_hash)
@@ -737,16 +789,12 @@ UpdateResult Updater::perform_update(const std::string &new_binary_path, const s
         throw std::runtime_error("New binary not found: " + new_path);
     }
 
-    if (fs::exists(old_path))
+    try
     {
-        try
-        {
-            fs::remove(old_path);
-        }
-        catch (const fs::filesystem_error &)
-        {
-            print_error("Warning: Could not remove previous backup file: " + old_path + "\n");
-        }
+        fs::remove(old_path);
+    }
+    catch (const fs::filesystem_error &)
+    {
     }
 
 #ifdef __APPLE__
@@ -765,8 +813,23 @@ UpdateResult Updater::perform_update(const std::string &new_binary_path, const s
     }
 #endif
 
+    auto cleanup_macos_temp = [&]() {
+#ifdef __APPLE__
+        try
+        {
+            fs::path td = fs::path(current_binary_path).parent_path() / ".torrent_builder_update";
+            if (fs::exists(td))
+                fs::remove_all(td);
+        }
+        catch (const fs::filesystem_error &)
+        {
+        }
+#endif
+    };
+
     if (!make_executable(new_path))
     {
+        cleanup_macos_temp();
         throw std::runtime_error("Failed to set executable permissions on new binary");
     }
 
@@ -776,11 +839,14 @@ UpdateResult Updater::perform_update(const std::string &new_binary_path, const s
         fs::rename(current_binary_path, old_path);
         fs::rename(new_path, current_binary_path);
     }
-    catch (const fs::filesystem_error &)
+    catch (const fs::filesystem_error &e)
     {
+        log_message("Direct rename failed on Windows, falling back to batch script: " + std::string(e.what()), LogLevel::WARNING);
         std::string esc_current = escape_batch_path(current_binary_path);
         std::string esc_old = escape_batch_path(old_path);
         std::string esc_new = escape_batch_path(new_path);
+
+        bool step1_done = fs::exists(old_path) && !fs::exists(current_binary_path);
 
         std::string script_path = current_binary_path + ".update.bat";
         {
@@ -790,9 +856,28 @@ UpdateResult Updater::perform_update(const std::string &new_binary_path, const s
                 throw std::runtime_error("Failed to create update script");
             }
             script << "@echo off\n";
+            script << "set tries=0\n";
             script << "timeout /t 2 /nobreak >nul\n";
-            script << "move /y \"" << esc_current << "\" \"" << esc_old << "\"\n";
-            script << "move /y \"" << esc_new << "\" \"" << esc_current << "\"\n";
+            if (!step1_done)
+            {
+                script << ":retry_old\n";
+                script << "move /y \"" << esc_current << "\" \"" << esc_old << "\" >nul 2>&1\n";
+                script << "if not errorlevel 1 goto step2\n";
+                script << "set /a tries+=1\n";
+                script << "if %tries% geq 30 goto done\n";
+                script << "timeout /t 1 /nobreak >nul\n";
+                script << "goto retry_old\n";
+            }
+            script << ":step2\n";
+            script << "set tries=0\n";
+            script << ":retry_new\n";
+            script << "move /y \"" << esc_new << "\" \"" << esc_current << "\" >nul 2>&1\n";
+            script << "if not errorlevel 1 goto done\n";
+            script << "set /a tries+=1\n";
+            script << "if %tries% geq 30 goto done\n";
+            script << "timeout /t 1 /nobreak >nul\n";
+            script << "goto retry_new\n";
+            script << ":done\n";
             script << "del \"%~f0\"\n";
         }
 
@@ -815,6 +900,7 @@ UpdateResult Updater::perform_update(const std::string &new_binary_path, const s
     }
     catch (const fs::filesystem_error &e)
     {
+        cleanup_macos_temp();
         throw std::runtime_error("Failed to backup current binary: " + std::string(e.what()));
     }
 
@@ -833,7 +919,8 @@ UpdateResult Updater::perform_update(const std::string &new_binary_path, const s
                                                current_binary_path, new_path,
                                                std::make_error_code(std::errc::operation_not_permitted));
                 }
-                fs::remove(new_path);
+                std::error_code remove_ec;
+                fs::remove(new_path, remove_ec);
             }
             else
             {
@@ -843,17 +930,7 @@ UpdateResult Updater::perform_update(const std::string &new_binary_path, const s
     }
     catch (const fs::filesystem_error &e)
     {
-#ifdef __APPLE__
-        try
-        {
-            fs::path temp_dir = fs::path(current_binary_path).parent_path() / ".torrent_builder_update";
-            if (fs::exists(temp_dir))
-                fs::remove_all(temp_dir);
-        }
-        catch (const fs::filesystem_error &)
-        {
-        }
-#endif
+        cleanup_macos_temp();
         try
         {
             fs::rename(old_path, current_binary_path);
@@ -869,24 +946,12 @@ UpdateResult Updater::perform_update(const std::string &new_binary_path, const s
     }
 #endif
 
-#ifdef __APPLE__
-    try
-    {
-        fs::path temp_dir = fs::path(current_binary_path).parent_path() / ".torrent_builder_update";
-        if (fs::exists(temp_dir))
-        {
-            fs::remove_all(temp_dir);
-        }
-    }
-    catch (const fs::filesystem_error &)
-    {
-    }
-#endif
+    cleanup_macos_temp();
 
     return UpdateResult::Success;
 }
 
-bool Updater::perform_rollback(const std::string &current_binary_path)
+UpdateResult Updater::perform_rollback(const std::string &current_binary_path)
 {
     log_message("Starting rollback for: " + current_binary_path, LogLevel::INFO);
     std::string old_path = get_old_binary_path(current_binary_path);
@@ -900,10 +965,11 @@ bool Updater::perform_rollback(const std::string &current_binary_path)
     try
     {
         fs::rename(old_path, current_binary_path);
-        return true;
+        return UpdateResult::Success;
     }
-    catch (const fs::filesystem_error &)
+    catch (const fs::filesystem_error &e)
     {
+        log_message("Direct rename failed on Windows rollback, falling back to batch script: " + std::string(e.what()), LogLevel::WARNING);
     }
 
     std::string esc_current = escape_batch_path(current_binary_path);
@@ -917,8 +983,16 @@ bool Updater::perform_rollback(const std::string &current_binary_path)
             throw std::runtime_error("Failed to create rollback script");
         }
         script << "@echo off\n";
+        script << "set tries=0\n";
         script << "timeout /t 2 /nobreak >nul\n";
-        script << "move /y \"" << esc_old << "\" \"" << esc_current << "\"\n";
+        script << ":retry\n";
+        script << "move /y \"" << esc_old << "\" \"" << esc_current << "\" >nul 2>&1\n";
+        script << "if not errorlevel 1 goto done\n";
+        script << "set /a tries+=1\n";
+        script << "if %tries% geq 30 goto done\n";
+        script << "timeout /t 1 /nobreak >nul\n";
+        script << "goto retry\n";
+        script << ":done\n";
         script << "del \"%~f0\"\n";
     }
 
@@ -931,6 +1005,8 @@ bool Updater::perform_rollback(const std::string &current_binary_path)
         fs::remove(script_path);
         throw std::runtime_error("Failed to launch rollback script");
     }
+    log_message("Rollback scheduled via batch script: " + script_path, LogLevel::INFO);
+    return UpdateResult::PendingRestart;
 #else
     std::string temp_path = current_binary_path + ".rbtmp";
     try
@@ -952,7 +1028,7 @@ bool Updater::perform_rollback(const std::string &current_binary_path)
         catch (const fs::filesystem_error &restore_err)
         {
             log_message("Rollback restore also failed: " + std::string(restore_err.what()) +
-                        " — binary may be missing at " + current_binary_path, LogLevel::ERR);
+                        " — binary may be missing at " + current_binary_path + ", backup at " + temp_path, LogLevel::ERR);
         }
         throw std::runtime_error("Rollback failed: " + std::string(e.what()));
     }
@@ -966,5 +1042,5 @@ bool Updater::perform_rollback(const std::string &current_binary_path)
     }
 #endif
 
-    return true;
+    return UpdateResult::Success;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -770,4 +770,104 @@ void atomic_write(const std::filesystem::path &dest, const std::vector<char> &da
 #endif
 }
 
+Version parse_version(const std::string &version_str)
+{
+    Version v;
+    std::string cleaned = version_str;
+
+    if (cleaned.starts_with('v') || cleaned.starts_with('V'))
+    {
+        cleaned = cleaned.substr(1);
+    }
+
+    auto dash_pos = cleaned.find('-');
+    if (dash_pos != std::string::npos)
+    {
+        v.prerelease = cleaned.substr(dash_pos + 1);
+        cleaned = cleaned.substr(0, dash_pos);
+    }
+
+    if (cleaned.empty() || cleaned == "dev")
+    {
+        return v;
+    }
+
+    auto parts = split(cleaned, '.');
+    if (!parts.empty())
+    {
+        try { v.major = std::stoi(parts[0]); } catch (...) {}
+    }
+    if (parts.size() > 1)
+    {
+        try { v.minor = std::stoi(parts[1]); } catch (...) {}
+    }
+    if (parts.size() > 2)
+    {
+        try { v.patch = std::stoi(parts[2]); } catch (...) {}
+    }
+    return v;
+}
+
+namespace {
+
+int compare_prerelease_identifiers(const std::string &a, const std::string &b)
+{
+    auto split_dots = [](const std::string &s) {
+        std::vector<std::string> out;
+        size_t start = 0;
+        for (size_t i = 0; i <= s.size(); ++i)
+        {
+            if (i == s.size() || s[i] == '.')
+            {
+                out.push_back(s.substr(start, i - start));
+                start = i + 1;
+            }
+        }
+        return out;
+    };
+
+    if (a.empty() && b.empty()) return 0;
+    if (a.empty()) return 1;
+    if (b.empty()) return -1;
+
+    auto pa = split_dots(a);
+    auto pb = split_dots(b);
+    size_t n = std::min(pa.size(), pb.size());
+    for (size_t i = 0; i < n; ++i)
+    {
+        bool a_num = !pa[i].empty() && std::all_of(pa[i].begin(), pa[i].end(), [](unsigned char c) { return std::isdigit(c); });
+        bool b_num = !pb[i].empty() && std::all_of(pb[i].begin(), pb[i].end(), [](unsigned char c) { return std::isdigit(c); });
+
+        if (a_num && b_num)
+        {
+            long ai = std::stol(pa[i]);
+            long bi = std::stol(pb[i]);
+            if (ai != bi) return ai < bi ? -1 : 1;
+        }
+        else if (a_num != b_num)
+        {
+            return a_num ? -1 : 1;
+        }
+        else
+        {
+            if (pa[i] != pb[i]) return pa[i] < pb[i] ? -1 : 1;
+        }
+    }
+    if (pa.size() != pb.size()) return pa.size() < pb.size() ? -1 : 1;
+    return 0;
+}
+
+} // namespace
+
+int compare_versions(const std::string &v1, const std::string &v2)
+{
+    auto a = parse_version(v1);
+    auto b = parse_version(v2);
+
+    if (a.major != b.major) return a.major < b.major ? -1 : 1;
+    if (a.minor != b.minor) return a.minor < b.minor ? -1 : 1;
+    if (a.patch != b.patch) return a.patch < b.patch ? -1 : 1;
+    return compare_prerelease_identifiers(a.prerelease, b.prerelease);
+}
+
 } // namespace utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,6 +3,7 @@
 #include "logger.hpp"
 #include <regex>
 #include <cctype>
+#include <climits>
 #include <algorithm>
 #include <format>
 #include <sstream>
@@ -840,8 +841,9 @@ int compare_prerelease_identifiers(const std::string &a, const std::string &b)
 
         if (a_num && b_num)
         {
-            long ai = std::stol(pa[i]);
-            long bi = std::stol(pb[i]);
+            long ai = 0, bi = 0;
+            try { ai = std::stol(pa[i]); } catch (...) { log_message("Prerelease identifier overflow, clamped to LONG_MAX: " + pa[i], LogLevel::WARNING); ai = LONG_MAX; }
+            try { bi = std::stol(pb[i]); } catch (...) { log_message("Prerelease identifier overflow, clamped to LONG_MAX: " + pb[i], LogLevel::WARNING); bi = LONG_MAX; }
             if (ai != bi) return ai < bi ? -1 : 1;
         }
         else if (a_num != b_num)

--- a/tests/test_updater.cpp
+++ b/tests/test_updater.cpp
@@ -226,6 +226,14 @@ TEST_F(CompareVersionsTest, PreReleaseIdentifierOrdering)
     EXPECT_LT(utils::compare_versions("1.0.0-1", "1.0.0-alpha"), 0);
 }
 
+TEST_F(CompareVersionsTest, PreReleaseNumericOverflow)
+{
+    std::string huge = "1.0.0-" + std::string(30, '9');
+    std::string huge2 = "1.0.0-" + std::string(30, '9');
+    EXPECT_EQ(utils::compare_versions(huge, huge2), 0);
+    EXPECT_GT(utils::compare_versions(huge, "1.0.0-999999"), 0);
+}
+
 class PlatformInfoTest : public ::testing::Test
 {
 };
@@ -411,6 +419,20 @@ TEST_F(FindMatchingAssetFromJsonTest, NoMatchFromParsedJson)
     EXPECT_FALSE(result.has_value());
 }
 
+TEST_F(FindMatchingAssetFromJsonTest, SkipsAssetWithEmptyUrl)
+{
+    nlohmann::json j = R"({
+        "assets": [
+            {"name": "torrent_builder_2.0.0_linux_amd64", "browser_download_url": ""},
+            {"name": "torrent_builder_2.0.0_linux_amd64", "browser_download_url": "https://example.com/valid"}
+        ]
+    })"_json;
+    PlatformInfo platform{"linux", "amd64"};
+    auto result = Updater::find_matching_asset_from_json(j, platform);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "https://example.com/valid");
+}
+
 class LookupChecksumTest : public ::testing::Test
 {
 };
@@ -443,6 +465,14 @@ TEST_F(LookupChecksumTest, EmptyContentReturnsNullopt)
 {
     auto result = Updater::lookup_checksum("", "any_file");
     EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(LookupChecksumTest, HandlesBsdStarFormat)
+{
+    std::string checksums = "abc123def456 *torrent_builder_1.0.0_linux_amd64\n";
+    auto result = Updater::lookup_checksum(checksums, "torrent_builder_1.0.0_linux_amd64");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "abc123def456");
 }
 
 class MockedUpdaterTest : public ::testing::Test
@@ -486,6 +516,16 @@ protected:
 
 class FetchLatestReleaseTest : public MockedUpdaterTest
 {
+protected:
+    void TearDown() override
+    {
+        MockedUpdaterTest::TearDown();
+#ifdef _WIN32
+        _putenv_s("GITHUB_TOKEN", "");
+#else
+        unsetenv("GITHUB_TOKEN");
+#endif
+    }
 };
 
 TEST_F(FetchLatestReleaseTest, ReturnsValidRelease)
@@ -518,7 +558,7 @@ TEST_F(FetchLatestReleaseTest, TagWithoutVPrefix)
 
 TEST_F(FetchLatestReleaseTest, RateLimitResponse)
 {
-    setup_curl_mock(R"({"message": "API rate limit exceeded for user", "status": "403"})");
+    setup_curl_mock(R"({"message": "API rate limit exceeded for user", "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"})");
 
     EXPECT_THROW(
         { auto r = Updater::fetch_latest_release(); },
@@ -573,6 +613,63 @@ TEST_F(FetchLatestReleaseTest, CurlNetworkError)
     catch (const std::runtime_error &e)
     {
         EXPECT_NE(std::string(e.what()).find("Failed to fetch release info"), std::string::npos);
+    }
+}
+
+TEST_F(FetchLatestReleaseTest, SendsGithubTokenHeader)
+{
+    auto captured_args = std::make_shared<std::vector<std::string>>();
+    Updater::set_curl_executor_for_testing(
+        [captured_args](const std::string &, const std::vector<std::string> &args) -> std::string
+        {
+            *captured_args = args;
+            return make_release_json("v2.0.0");
+        });
+
+#ifdef _WIN32
+    _putenv_s("GITHUB_TOKEN", "test_token_123");
+#else
+    setenv("GITHUB_TOKEN", "test_token_123", 1);
+#endif
+
+    Updater::fetch_latest_release();
+
+    Updater::reset_test_overrides();
+
+    bool found_auth = false;
+    for (size_t i = 0; i < captured_args->size(); ++i)
+    {
+        if ((*captured_args)[i] == "Authorization: Bearer test_token_123")
+        {
+            found_auth = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found_auth);
+}
+
+TEST_F(FetchLatestReleaseTest, NoAuthHeaderWithoutToken)
+{
+    auto captured_args = std::make_shared<std::vector<std::string>>();
+    Updater::set_curl_executor_for_testing(
+        [captured_args](const std::string &, const std::vector<std::string> &args) -> std::string
+        {
+            *captured_args = args;
+            return make_release_json("v2.0.0");
+        });
+
+#ifdef _WIN32
+    _putenv_s("GITHUB_TOKEN", "");
+#else
+    unsetenv("GITHUB_TOKEN");
+#endif
+
+    Updater::fetch_latest_release();
+    Updater::reset_test_overrides();
+
+    for (const auto &arg : *captured_args)
+    {
+        EXPECT_EQ(arg.find("Authorization"), std::string::npos);
     }
 }
 
@@ -664,6 +761,58 @@ TEST_F(DownloadAssetTest, MockReceivesExpectedSize)
 TEST_F(DownloadAssetTest, RejectsNonHttpsUrl)
 {
     EXPECT_FALSE(Updater::download_asset("file:///nonexistent/path/that/does/not/exist", "/tmp/tb_test_dl"));
+}
+
+class VerifyDownloadedFileTest : public ::testing::Test
+{
+protected:
+    fs::path temp_file;
+
+    void SetUp() override
+    {
+        temp_file = fs::temp_directory_path() / "tb_verify_test";
+    }
+
+    void TearDown() override
+    {
+        fs::remove(temp_file);
+    }
+
+    void write_file(const std::string &content)
+    {
+        std::ofstream f(temp_file, std::ios::binary);
+        f << content;
+    }
+};
+
+TEST_F(VerifyDownloadedFileTest, AcceptsCorrectSize)
+{
+    write_file(std::string(100, 'X'));
+    EXPECT_TRUE(Updater::verify_downloaded_file(temp_file.string(), 100));
+}
+
+TEST_F(VerifyDownloadedFileTest, RejectsSizeMismatch)
+{
+    write_file(std::string(50, 'X'));
+    EXPECT_FALSE(Updater::verify_downloaded_file(temp_file.string(), 100));
+}
+
+TEST_F(VerifyDownloadedFileTest, AcceptsAnySizeWhenExpectedIsZero)
+{
+    write_file("small");
+    EXPECT_TRUE(Updater::verify_downloaded_file(temp_file.string(), 0));
+}
+
+TEST_F(VerifyDownloadedFileTest, RejectsEmptyFile)
+{
+    write_file("");
+    EXPECT_FALSE(Updater::verify_downloaded_file(temp_file.string(), 0));
+}
+
+TEST_F(VerifyDownloadedFileTest, RejectsMissingFile)
+{
+    fs::remove(temp_file);
+    EXPECT_FALSE(Updater::verify_downloaded_file(temp_file.string(), 0));
 }
 
 class GetExePathTest : public MockedUpdaterTest
@@ -792,7 +941,7 @@ TEST_F(PerformRollbackTest, RestoresOldVersion)
     write_file("current_bin", "new version");
     write_file("current_bin.old", "old version");
 
-    EXPECT_TRUE(Updater::perform_rollback(current));
+    EXPECT_EQ(Updater::perform_rollback(current), UpdateResult::Success);
     EXPECT_FALSE(fs::exists(temp_dir / "current_bin.old"));
     EXPECT_EQ(read_file("current_bin"), "old version");
 }
@@ -895,6 +1044,20 @@ TEST_F(VerifyChecksumMatchTest, ReturnsTrueForUpperCaseHash)
 
     const std::string expected_hash =
         "6AE8A75555209FD6C44157C0AED8016E763FF435A19CF186F76863140143FF72";
+
+    EXPECT_TRUE(Updater::verify_checksum(filepath, expected_hash));
+}
+
+TEST_F(VerifyChecksumMatchTest, HandlesMultiChunkInput)
+{
+    std::string filepath = (temp_dir / "test_large").string();
+    {
+        std::ofstream f(filepath, std::ios::binary);
+        f << std::string(10000, 'A');
+    }
+
+    const std::string expected_hash =
+        "85757d9ef5868bb53472a6be8d81d1e3c398546b69b107141ad336053c40cb54";
 
     EXPECT_TRUE(Updater::verify_checksum(filepath, expected_hash));
 }
@@ -1053,6 +1216,23 @@ TEST_F(FetchChecksumsTest, JsonOverloadReturnsNulloptWhenNoChecksumsAsset)
     EXPECT_FALSE(result.has_value());
 }
 
+TEST_F(FetchChecksumsTest, JsonOverloadReturnsNulloptOnCurlFailure)
+{
+    nlohmann::json j = nlohmann::json::parse(make_release_json("v1.0.0", "", {
+        {"checksums.txt", "https://example.com/checksums.txt"},
+        {"torrent_builder_1.0.0_linux_amd64", "https://example.com/binary"}
+    }));
+
+    Updater::set_curl_executor_for_testing(
+        [](const std::string &url, const std::vector<std::string> &) -> std::string
+        {
+            throw std::runtime_error("Connection refused");
+        });
+
+    auto result = Updater::fetch_checksums(j);
+    EXPECT_FALSE(result.has_value());
+}
+
 int handle_update_command(const std::vector<std::string> &args);
 
 class HandleUpdateCommandTest : public MockedUpdaterTest
@@ -1062,6 +1242,7 @@ protected:
     std::streambuf *old_cerr_ = nullptr;
     std::ostringstream captured_out_;
     std::ostringstream captured_err_;
+    std::vector<fs::path> cleanup_paths_;
 
     void SetUp() override
     {
@@ -1074,6 +1255,8 @@ protected:
         std::cout.rdbuf(old_cout_);
         std::cerr.rdbuf(old_cerr_);
         Updater::reset_test_overrides();
+        for (const auto &p : cleanup_paths_)
+            fs::remove_all(p);
     }
 
     static std::string release_with_version(const std::string &version)
@@ -1114,6 +1297,16 @@ TEST_F(HandleUpdateCommandTest, HelpReturnsZero)
     EXPECT_NE(captured_out_.str().find("update"), std::string::npos);
 }
 
+TEST_F(HandleUpdateCommandTest, RejectsEmptyVersionTag)
+{
+    nlohmann::json j;
+    j["assets"] = nlohmann::json::array();
+    setup_curl_mock(j.dump());
+
+    EXPECT_EQ(handle_update_command({"--check"}), 1);
+    EXPECT_NE(captured_err_.str().find("latest release version"), std::string::npos);
+}
+
 TEST_F(HandleUpdateCommandTest, CheckShowsUpdateAvailable)
 {
     Updater::set_current_version_for_testing("0.5.0");
@@ -1122,6 +1315,34 @@ TEST_F(HandleUpdateCommandTest, CheckShowsUpdateAvailable)
     EXPECT_EQ(handle_update_command({"--check"}), 0);
     EXPECT_NE(captured_out_.str().find("2.0.0"), std::string::npos);
     EXPECT_NE(captured_out_.str().find("Update available"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, ChangelogStripsAnsiEscapes)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+    std::string body = "\x1b[1;31;40mBold red\x1b[0m and \x1b[2Jclear and \x1b[Hhome";
+    setup_curl_mock(make_release_json("v2.0.0", body, {
+        {"torrent_builder_2.0.0_linux_amd64", "https://example.com/binary"}
+    }));
+
+    handle_update_command({"--check"});
+    EXPECT_EQ(captured_out_.str().find('\x1b'), std::string::npos);
+    EXPECT_NE(captured_out_.str().find("Bold red"), std::string::npos);
+    EXPECT_NE(captured_out_.str().find("clear"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, ChangelogStripsOscAndCharsetEscapes)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+    std::string body = "\x1b]0;Title\x07OSC and \x1b(Bcharset\x1b[31mred\x1b[0m";
+    setup_curl_mock(make_release_json("v2.0.0", body, {
+        {"torrent_builder_2.0.0_linux_amd64", "https://example.com/binary"}
+    }));
+
+    handle_update_command({"--check"});
+    EXPECT_EQ(captured_out_.str().find('\x1b'), std::string::npos);
+    EXPECT_EQ(captured_out_.str().find("]0;Title"), std::string::npos);
+    EXPECT_NE(captured_out_.str().find("red"), std::string::npos);
 }
 
 TEST_F(HandleUpdateCommandTest, CheckShowsAlreadyUpToDate)
@@ -1158,6 +1379,7 @@ TEST_F(HandleUpdateCommandTest, YesFlagSkipsPrompt)
 
     fs::path temp = fs::temp_directory_path() / "tb_handle_update_test";
     fs::create_directories(temp);
+    cleanup_paths_.push_back(temp);
     std::string fake_bin = (temp / "current").string();
     std::string old_bin = fake_bin + ".old";
     {
@@ -1183,7 +1405,6 @@ TEST_F(HandleUpdateCommandTest, YesFlagSkipsPrompt)
     int rc = handle_update_command({"--yes"});
 
     Updater::reset_test_overrides();
-    fs::remove_all(temp);
 
     EXPECT_EQ(rc, 0);
 }
@@ -1208,6 +1429,7 @@ TEST_F(HandleUpdateCommandTest, RollbackSuccess)
 {
     fs::path temp = fs::temp_directory_path() / "tb_rollback_cmd_test";
     fs::create_directories(temp);
+    cleanup_paths_.push_back(temp);
     std::string fake_bin = (temp / "current").string();
     std::string old_bin = fake_bin + ".old";
 
@@ -1227,8 +1449,6 @@ TEST_F(HandleUpdateCommandTest, RollbackSuccess)
 
     std::cin.rdbuf(old_cin);
 
-    fs::remove_all(temp);
-
     EXPECT_EQ(rc, 0);
 }
 
@@ -1236,6 +1456,7 @@ TEST_F(HandleUpdateCommandTest, RollbackCancelled)
 {
     fs::path temp = fs::temp_directory_path() / "tb_rollback_cancel_test";
     fs::create_directories(temp);
+    cleanup_paths_.push_back(temp);
     std::string fake_bin = (temp / "current").string();
     std::string old_bin = fake_bin + ".old";
 
@@ -1255,8 +1476,6 @@ TEST_F(HandleUpdateCommandTest, RollbackCancelled)
 
     EXPECT_EQ(rc, 0);
     EXPECT_NE(captured_out_.str().find("cancelled"), std::string::npos);
-
-    fs::remove_all(temp);
 }
 
 TEST_F(HandleUpdateCommandTest, RollbackNoOldFileReturnsOne)
@@ -1271,6 +1490,35 @@ TEST_F(HandleUpdateCommandTest, RollbackNoOldFileReturnsOne)
     std::cin.rdbuf(old_cin);
 
     EXPECT_EQ(rc, 1);
+}
+
+TEST_F(HandleUpdateCommandTest, RollbackYesFlagSkipsPrompt)
+{
+    fs::path temp = fs::temp_directory_path() / "tb_rollback_yes_test";
+    fs::create_directories(temp);
+    cleanup_paths_.push_back(temp);
+    std::string fake_bin = (temp / "current").string();
+    std::string old_bin = fake_bin + ".old";
+
+    {
+        std::ofstream(fake_bin) << "new binary";
+        std::ofstream(old_bin) << "old binary";
+    }
+    fs::permissions(fake_bin, fs::perms::owner_all);
+    fs::permissions(old_bin, fs::perms::owner_all);
+
+    Updater::set_exe_path_provider_for_testing([fake_bin]() { return fake_bin; });
+
+    std::istringstream empty_input("");
+    auto *old_cin = std::cin.rdbuf(empty_input.rdbuf());
+
+    int rc = handle_update_command({"--rollback", "--yes"});
+
+    std::cin.rdbuf(old_cin);
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_NE(captured_out_.str().find("rolled back"), std::string::npos);
+    EXPECT_TRUE(fs::exists(fake_bin));
 }
 
 TEST_F(HandleUpdateCommandTest, NoMatchingPlatformReturnsOne)
@@ -1322,6 +1570,7 @@ TEST_F(HandleUpdateCommandTest, ChecksumVerificationSuccess)
 
     fs::path temp = fs::temp_directory_path() / "tb_checksum_verify_test";
     fs::create_directories(temp);
+    cleanup_paths_.push_back(temp);
     std::string fake_bin = (temp / "current").string();
     {
         std::ofstream(fake_bin) << "old binary";
@@ -1347,7 +1596,6 @@ TEST_F(HandleUpdateCommandTest, ChecksumVerificationSuccess)
     int rc = handle_update_command({"--yes"});
 
     Updater::reset_test_overrides();
-    fs::remove_all(temp);
 
     EXPECT_EQ(rc, 0);
     EXPECT_NE(captured_out_.str().find("Checksum verified"), std::string::npos);
@@ -1380,6 +1628,7 @@ TEST_F(HandleUpdateCommandTest, ChecksumMismatchReturnsOne)
 
     fs::path temp = fs::temp_directory_path() / "tb_checksum_mismatch_test";
     fs::create_directories(temp);
+    cleanup_paths_.push_back(temp);
     std::string fake_bin = (temp / "current").string();
     {
         std::ofstream(fake_bin) << "old binary";
@@ -1398,7 +1647,6 @@ TEST_F(HandleUpdateCommandTest, ChecksumMismatchReturnsOne)
     int rc = handle_update_command({"--yes"});
 
     Updater::reset_test_overrides();
-    fs::remove_all(temp);
 
     EXPECT_EQ(rc, 1);
     EXPECT_NE(captured_err_.str().find("Checksum verification failed"), std::string::npos);
@@ -1459,6 +1707,7 @@ TEST_F(HandleUpdateCommandTest, ProceedsWithoutChecksumsWhenAbsentFromRelease)
 
     fs::path temp = fs::temp_directory_path() / "tb_no_checksums_test";
     fs::create_directories(temp);
+    cleanup_paths_.push_back(temp);
     std::string fake_bin = (temp / "current").string();
     {
         std::ofstream(fake_bin) << "old binary";
@@ -1483,7 +1732,6 @@ TEST_F(HandleUpdateCommandTest, ProceedsWithoutChecksumsWhenAbsentFromRelease)
     int rc = handle_update_command({"--yes"});
 
     Updater::reset_test_overrides();
-    fs::remove_all(temp);
 
     EXPECT_EQ(rc, 0);
     EXPECT_NE(captured_out_.str().find("Successfully updated"), std::string::npos);
@@ -1516,6 +1764,7 @@ TEST_F(HandleUpdateCommandTest, ProceedsWithoutChecksumWhenAssetNotListed)
 
     fs::path temp = fs::temp_directory_path() / "tb_no_asset_checksum_test";
     fs::create_directories(temp);
+    cleanup_paths_.push_back(temp);
     std::string fake_bin = (temp / "current").string();
     {
         std::ofstream(fake_bin) << "old binary";
@@ -1540,10 +1789,47 @@ TEST_F(HandleUpdateCommandTest, ProceedsWithoutChecksumWhenAssetNotListed)
     int rc = handle_update_command({"--yes"});
 
     Updater::reset_test_overrides();
-    fs::remove_all(temp);
 
     EXPECT_EQ(rc, 0);
     EXPECT_NE(captured_out_.str().find("Successfully updated"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, RejectsInvalidBinaryWithoutChecksum)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+
+    std::string asset_name = asset_name_for_version("2.0.0");
+
+    nlohmann::json j;
+    j["tag_name"] = "v2.0.0";
+    j["body"] = "Test release";
+    j["assets"] = nlohmann::json::array();
+    j["assets"].push_back({{"name", asset_name},
+                           {"browser_download_url", "https://github.com/user/repo/releases/download/v2.0.0/" + asset_name}});
+
+    Updater::set_curl_executor_for_testing(
+        [j](const std::string &, const std::vector<std::string> &) -> std::string
+        {
+            return j.dump();
+        });
+
+    Updater::set_exe_path_provider_for_testing([]() { return "/nonexistent/binary"; });
+
+    Updater::set_binary_validator_for_testing([](const std::string &) { return false; });
+
+    Updater::set_file_downloader_for_testing(
+        [](const std::string &, const std::string &dest_path, int64_t) -> bool
+        {
+            std::ofstream(dest_path) << "not a valid binary";
+            return true;
+        });
+
+    int rc = handle_update_command({"--yes"});
+
+    Updater::reset_test_overrides();
+
+    EXPECT_EQ(rc, 1);
+    EXPECT_NE(captured_err_.str().find("not a valid binary"), std::string::npos);
 }
 
 class IsValidBinaryTest : public ::testing::Test
@@ -1611,6 +1897,21 @@ TEST_F(IsValidBinaryTest, RejectsNonBinary)
     EXPECT_FALSE(Updater::is_valid_binary(path.string()));
     fs::remove(path);
 }
+
+#ifdef __APPLE__
+TEST_F(IsValidBinaryTest, RecognizesZipMagic)
+{
+    auto path = fs::temp_directory_path() / "test_zip_file";
+    {
+        std::ofstream f(path, std::ios::binary);
+        unsigned char zip_magic[] = {0x50, 0x4b, 0x03, 0x04};
+        f.write(reinterpret_cast<const char *>(zip_magic), 4);
+        f << "fake zip content";
+    }
+    EXPECT_TRUE(Updater::is_valid_binary(path.string()));
+    fs::remove(path);
+}
+#endif
 
 TEST_F(IsValidBinaryTest, RejectsMissingFile)
 {

--- a/tests/test_updater.cpp
+++ b/tests/test_updater.cpp
@@ -1,0 +1,1739 @@
+#include <gtest/gtest.h>
+#include "utils.hpp"
+#include "updater.hpp"
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <filesystem>
+#include <cstdio>
+
+#ifdef __APPLE__
+#include <openssl/evp.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace
+{
+#ifdef __APPLE__
+std::string sha256_file(const std::string &filepath)
+{
+    std::ifstream file(filepath, std::ios::binary);
+    if (!file)
+        return "";
+
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx)
+        return "";
+
+    EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr);
+
+    char buf[8192];
+    while (file.read(buf, sizeof(buf)) || file.gcount() > 0)
+    {
+        EVP_DigestUpdate(ctx, buf, static_cast<size_t>(file.gcount()));
+    }
+
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int digest_len = 0;
+    EVP_DigestFinal_ex(ctx, digest, &digest_len);
+    EVP_MD_CTX_free(ctx);
+
+    std::string result;
+    result.reserve(digest_len * 2);
+    for (unsigned int i = 0; i < digest_len; ++i)
+    {
+        char hex[3];
+        std::snprintf(hex, sizeof(hex), "%02x", digest[i]);
+        result += hex;
+    }
+    return result;
+}
+
+bool create_mock_zip(const std::string &dest_path, const std::string &binary_content)
+{
+    fs::path staging = fs::temp_directory_path() / "tb_mock_zip_staging";
+    fs::remove_all(staging);
+    fs::create_directories(staging);
+    {
+        std::ofstream f(staging / "torrent_builder", std::ios::binary);
+        f << binary_content;
+    }
+    fs::permissions(staging / "torrent_builder", fs::perms::owner_all);
+
+    fs::remove(dest_path);
+    std::string cmd = "cd \"" + staging.string() + "\" && zip -r \"" + dest_path + "\" torrent_builder > /dev/null 2>&1";
+    int rc = std::system(cmd.c_str());
+    fs::remove_all(staging);
+    return rc == 0;
+}
+#endif
+}
+
+class ParseVersionTest : public ::testing::Test
+{
+};
+
+TEST_F(ParseVersionTest, StandardVersion)
+{
+    auto v = utils::parse_version("1.2.3");
+    EXPECT_EQ(v.major, 1);
+    EXPECT_EQ(v.minor, 2);
+    EXPECT_EQ(v.patch, 3);
+}
+
+TEST_F(ParseVersionTest, VersionWithVPrefix)
+{
+    auto v = utils::parse_version("v2.1.0");
+    EXPECT_EQ(v.major, 2);
+    EXPECT_EQ(v.minor, 1);
+    EXPECT_EQ(v.patch, 0);
+}
+
+TEST_F(ParseVersionTest, VersionWithUpperVPrefix)
+{
+    auto v = utils::parse_version("V3.0.1");
+    EXPECT_EQ(v.major, 3);
+    EXPECT_EQ(v.minor, 0);
+    EXPECT_EQ(v.patch, 1);
+}
+
+TEST_F(ParseVersionTest, VersionWithPreReleaseSuffix)
+{
+    auto v = utils::parse_version("1.0.0-rc1");
+    EXPECT_EQ(v.major, 1);
+    EXPECT_EQ(v.minor, 0);
+    EXPECT_EQ(v.patch, 0);
+    EXPECT_EQ(v.prerelease, "rc1");
+    EXPECT_TRUE(v.is_prerelease());
+}
+
+TEST_F(ParseVersionTest, VersionWithVPrefixAndPreRelease)
+{
+    auto v = utils::parse_version("v2.0.0-beta.1");
+    EXPECT_EQ(v.major, 2);
+    EXPECT_EQ(v.minor, 0);
+    EXPECT_EQ(v.patch, 0);
+}
+
+TEST_F(ParseVersionTest, TwoPartVersion)
+{
+    auto v = utils::parse_version("1.5");
+    EXPECT_EQ(v.major, 1);
+    EXPECT_EQ(v.minor, 5);
+    EXPECT_EQ(v.patch, 0);
+}
+
+TEST_F(ParseVersionTest, SinglePartVersion)
+{
+    auto v = utils::parse_version("42");
+    EXPECT_EQ(v.major, 42);
+    EXPECT_EQ(v.minor, 0);
+    EXPECT_EQ(v.patch, 0);
+}
+
+TEST_F(ParseVersionTest, DevVersion)
+{
+    auto v = utils::parse_version("dev");
+    EXPECT_EQ(v.major, 0);
+    EXPECT_EQ(v.minor, 0);
+    EXPECT_EQ(v.patch, 0);
+}
+
+TEST_F(ParseVersionTest, DevVersionWithHash)
+{
+    auto v = utils::parse_version("dev (abc1234)");
+    EXPECT_EQ(v.major, 0);
+    EXPECT_EQ(v.minor, 0);
+    EXPECT_EQ(v.patch, 0);
+}
+
+TEST_F(ParseVersionTest, EmptyString)
+{
+    auto v = utils::parse_version("");
+    EXPECT_EQ(v.major, 0);
+    EXPECT_EQ(v.minor, 0);
+    EXPECT_EQ(v.patch, 0);
+}
+
+TEST_F(ParseVersionTest, ZeroVersion)
+{
+    auto v = utils::parse_version("0.0.0");
+    EXPECT_EQ(v.major, 0);
+    EXPECT_EQ(v.minor, 0);
+    EXPECT_EQ(v.patch, 0);
+}
+
+class CompareVersionsTest : public ::testing::Test
+{
+};
+
+TEST_F(CompareVersionsTest, EqualVersions)
+{
+    EXPECT_EQ(utils::compare_versions("1.0.0", "1.0.0"), 0);
+    EXPECT_EQ(utils::compare_versions("2.3.4", "2.3.4"), 0);
+}
+
+TEST_F(CompareVersionsTest, FirstLessThanSecond)
+{
+    EXPECT_LT(utils::compare_versions("1.0.0", "2.0.0"), 0);
+    EXPECT_LT(utils::compare_versions("1.0.0", "1.1.0"), 0);
+    EXPECT_LT(utils::compare_versions("1.0.0", "1.0.1"), 0);
+}
+
+TEST_F(CompareVersionsTest, FirstGreaterThanSecond)
+{
+    EXPECT_GT(utils::compare_versions("2.0.0", "1.0.0"), 0);
+    EXPECT_GT(utils::compare_versions("1.1.0", "1.0.0"), 0);
+    EXPECT_GT(utils::compare_versions("1.0.1", "1.0.0"), 0);
+}
+
+TEST_F(CompareVersionsTest, DevVersionIsLessThanRelease)
+{
+    EXPECT_LT(utils::compare_versions("dev", "1.0.0"), 0);
+    EXPECT_LT(utils::compare_versions("dev (abc1234)", "0.1.0"), 0);
+}
+
+TEST_F(CompareVersionsTest, BothDev)
+{
+    EXPECT_EQ(utils::compare_versions("dev", "dev"), 0);
+}
+
+TEST_F(CompareVersionsTest, WithVPrefixes)
+{
+    EXPECT_EQ(utils::compare_versions("v1.0.0", "1.0.0"), 0);
+    EXPECT_LT(utils::compare_versions("v1.0.0", "v2.0.0"), 0);
+}
+
+TEST_F(CompareVersionsTest, PreReleaseLessThanRelease)
+{
+    EXPECT_LT(utils::compare_versions("1.0.0-rc1", "1.0.1"), 0);
+    EXPECT_LT(utils::compare_versions("1.0.0-rc1", "1.0.0"), 0);
+    EXPECT_EQ(utils::compare_versions("1.0.0-rc1", "1.0.0-rc1"), 0);
+}
+
+TEST_F(CompareVersionsTest, PreReleaseIdentifierOrdering)
+{
+    EXPECT_LT(utils::compare_versions("1.0.0-rc1", "1.0.0-rc2"), 0);
+    EXPECT_GT(utils::compare_versions("1.0.0-rc2", "1.0.0-rc1"), 0);
+    EXPECT_LT(utils::compare_versions("1.0.0-alpha", "1.0.0-beta"), 0);
+    EXPECT_LT(utils::compare_versions("1.0.0-alpha.1", "1.0.0-alpha.2"), 0);
+    EXPECT_LT(utils::compare_versions("1.0.0-alpha", "1.0.0-alpha.1"), 0);
+    EXPECT_LT(utils::compare_versions("1.0.0-1", "1.0.0-2"), 0);
+    EXPECT_GT(utils::compare_versions("1.0.0-rc.10", "1.0.0-rc.9"), 0);
+    EXPECT_LT(utils::compare_versions("1.0.0-1", "1.0.0-alpha"), 0);
+}
+
+class PlatformInfoTest : public ::testing::Test
+{
+};
+
+TEST_F(PlatformInfoTest, ReturnsValidPlatform)
+{
+    auto info = Updater::get_platform_info();
+    EXPECT_FALSE(info.os.empty());
+    EXPECT_FALSE(info.arch.empty());
+}
+
+TEST_F(PlatformInfoTest, OsIsKnownValue)
+{
+    auto info = Updater::get_platform_info();
+    EXPECT_TRUE(info.os == "linux" || info.os == "macos" || info.os == "windows" || info.os == "unknown");
+}
+
+TEST_F(PlatformInfoTest, ArchIsKnownValue)
+{
+    auto info = Updater::get_platform_info();
+    EXPECT_TRUE(info.arch == "amd64" || info.arch == "arm64" || info.arch == "unknown");
+}
+
+class GetCurrentVersionTest : public ::testing::Test
+{
+protected:
+    void TearDown() override { Updater::reset_test_overrides(); }
+};
+
+TEST_F(GetCurrentVersionTest, ReturnsNonEmpty)
+{
+    std::string version = Updater::get_current_version();
+    EXPECT_FALSE(version.empty());
+}
+
+TEST_F(GetCurrentVersionTest, OverrideVersion)
+{
+    Updater::set_current_version_for_testing("9.9.9");
+    EXPECT_EQ(Updater::get_current_version(), "9.9.9");
+}
+
+TEST_F(GetCurrentVersionTest, ResetRestoresReal)
+{
+    Updater::set_current_version_for_testing("9.9.9");
+    Updater::reset_test_overrides();
+    std::string v = Updater::get_current_version();
+    EXPECT_NE(v, "9.9.9");
+}
+
+class CurlDetectionTest : public ::testing::Test
+{
+};
+
+TEST_F(CurlDetectionTest, FindCurlReturnsNonEmpty)
+{
+    std::string curl = Updater::find_curl_executable();
+    EXPECT_FALSE(curl.empty());
+}
+
+class FindMatchingAssetTest : public ::testing::Test
+{
+};
+
+TEST_F(FindMatchingAssetTest, MatchesLinuxAmd64)
+{
+    std::string json = R"({
+        "assets": [
+            {"name": "torrent_builder_1.0.0_linux_amd64", "browser_download_url": "https://example.com/linux_amd64"},
+            {"name": "torrent_builder_1.0.0_linux_arm64", "browser_download_url": "https://example.com/linux_arm64"},
+            {"name": "torrent_builder_1.0.0_windows_amd64.exe", "browser_download_url": "https://example.com/windows_amd64"}
+        ]
+    })";
+    PlatformInfo platform{"linux", "amd64"};
+    auto result = Updater::find_matching_asset(json, platform);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "https://example.com/linux_amd64");
+}
+
+TEST_F(FindMatchingAssetTest, MatchesLinuxArm64)
+{
+    std::string json = R"({
+        "assets": [
+            {"name": "torrent_builder_1.0.0_linux_amd64", "browser_download_url": "https://example.com/linux_amd64"},
+            {"name": "torrent_builder_1.0.0_linux_arm64", "browser_download_url": "https://example.com/linux_arm64"}
+        ]
+    })";
+    PlatformInfo platform{"linux", "arm64"};
+    auto result = Updater::find_matching_asset(json, platform);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "https://example.com/linux_arm64");
+}
+
+TEST_F(FindMatchingAssetTest, MatchesWindowsAmd64)
+{
+    std::string json = R"({
+        "assets": [
+            {"name": "torrent_builder_1.0.0_linux_amd64", "browser_download_url": "https://example.com/linux_amd64"},
+            {"name": "torrent_builder_1.0.0_windows_amd64.exe", "browser_download_url": "https://example.com/windows_amd64"}
+        ]
+    })";
+    PlatformInfo platform{"windows", "amd64"};
+    auto result = Updater::find_matching_asset(json, platform);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "https://example.com/windows_amd64");
+}
+
+TEST_F(FindMatchingAssetTest, MatchesMacosArm64)
+{
+    std::string json = R"({
+        "assets": [
+            {"name": "torrent_builder_1.0.0_macos_arm64.zip", "browser_download_url": "https://example.com/macos_arm64"},
+            {"name": "torrent_builder_1.0.0_macos_amd64.zip", "browser_download_url": "https://example.com/macos_amd64"}
+        ]
+    })";
+    PlatformInfo platform{"macos", "arm64"};
+    auto result = Updater::find_matching_asset(json, platform);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "https://example.com/macos_arm64");
+}
+
+TEST_F(FindMatchingAssetTest, NoMatchReturnsNullopt)
+{
+    std::string json = R"({
+        "assets": [
+            {"name": "torrent_builder_1.0.0_linux_amd64", "browser_download_url": "https://example.com/linux_amd64"}
+        ]
+    })";
+    PlatformInfo platform{"windows", "arm64"};
+    auto result = Updater::find_matching_asset(json, platform);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FindMatchingAssetTest, EmptyAssetsReturnsNullopt)
+{
+    std::string json = R"({"assets": []})";
+    PlatformInfo platform{"linux", "amd64"};
+    auto result = Updater::find_matching_asset(json, platform);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FindMatchingAssetTest, NoAssetsKeyReturnsNullopt)
+{
+    std::string json = R"({"tag_name": "v1.0.0"})";
+    PlatformInfo platform{"linux", "amd64"};
+    auto result = Updater::find_matching_asset(json, platform);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FindMatchingAssetTest, InvalidJsonReturnsNullopt)
+{
+    std::string json = "not valid json";
+    PlatformInfo platform{"linux", "amd64"};
+    auto result = Updater::find_matching_asset(json, platform);
+    EXPECT_FALSE(result.has_value());
+}
+
+class FindMatchingAssetFromJsonTest : public ::testing::Test
+{
+};
+
+TEST_F(FindMatchingAssetFromJsonTest, MatchesFromParsedJson)
+{
+    nlohmann::json j = R"({
+        "assets": [
+            {"name": "torrent_builder_2.0.0_linux_amd64", "browser_download_url": "https://example.com/v2_linux"}
+        ]
+    })"_json;
+    PlatformInfo platform{"linux", "amd64"};
+    auto result = Updater::find_matching_asset_from_json(j, platform);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "https://example.com/v2_linux");
+}
+
+TEST_F(FindMatchingAssetFromJsonTest, NoMatchFromParsedJson)
+{
+    nlohmann::json j = R"({
+        "assets": [
+            {"name": "torrent_builder_2.0.0_linux_amd64", "browser_download_url": "https://example.com/v2_linux"}
+        ]
+    })"_json;
+    PlatformInfo platform{"macos", "arm64"};
+    auto result = Updater::find_matching_asset_from_json(j, platform);
+    EXPECT_FALSE(result.has_value());
+}
+
+class LookupChecksumTest : public ::testing::Test
+{
+};
+
+TEST_F(LookupChecksumTest, FindsExactMatch)
+{
+    std::string checksums = "abc123def456  torrent_builder_1.0.0_linux_amd64\n"
+                            "789abc123def  torrent_builder_1.0.0_linux_arm64\n";
+    auto result = Updater::lookup_checksum(checksums, "torrent_builder_1.0.0_linux_amd64");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "abc123def456");
+}
+
+TEST_F(LookupChecksumTest, NotFoundReturnsNullopt)
+{
+    std::string checksums = "abc123  other_file.bin\n";
+    auto result = Updater::lookup_checksum(checksums, "nonexistent_file");
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(LookupChecksumTest, HandlesMixedCase)
+{
+    std::string checksums = "ABC123DEF456  torrent_builder_1.0.0_linux_amd64\n";
+    auto result = Updater::lookup_checksum(checksums, "torrent_builder_1.0.0_linux_amd64");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "abc123def456");
+}
+
+TEST_F(LookupChecksumTest, EmptyContentReturnsNullopt)
+{
+    auto result = Updater::lookup_checksum("", "any_file");
+    EXPECT_FALSE(result.has_value());
+}
+
+class MockedUpdaterTest : public ::testing::Test
+{
+protected:
+    void TearDown() override { Updater::reset_test_overrides(); }
+
+    static std::string make_release_json(const std::string &version,
+                                          const std::string &body = "",
+                                          const std::vector<std::pair<std::string, std::string>> &assets = {})
+    {
+        nlohmann::json j;
+        j["tag_name"] = version;
+        j["body"] = body;
+        j["assets"] = nlohmann::json::array();
+        for (const auto &[name, url] : assets)
+        {
+            j["assets"].push_back({{"name", name}, {"browser_download_url", url}});
+        }
+        return j.dump();
+    }
+
+    void setup_curl_mock(const std::string &response)
+    {
+        Updater::set_curl_executor_for_testing(
+            [response](const std::string &, const std::vector<std::string> &) -> std::string
+            {
+                return response;
+            });
+    }
+
+    void setup_curl_mock_throwing(const std::string &msg)
+    {
+        Updater::set_curl_executor_for_testing(
+            [msg](const std::string &, const std::vector<std::string> &) -> std::string
+            {
+                throw std::runtime_error(msg);
+            });
+    }
+};
+
+class FetchLatestReleaseTest : public MockedUpdaterTest
+{
+};
+
+TEST_F(FetchLatestReleaseTest, ReturnsValidRelease)
+{
+    setup_curl_mock(make_release_json("v2.0.0", "Bug fixes", {
+        {"torrent_builder_2.0.0_linux_amd64", "https://example.com/binary"}
+    }));
+
+    auto result = Updater::fetch_latest_release();
+    EXPECT_EQ(result.version, "2.0.0");
+    EXPECT_EQ(result.changelog, "Bug fixes");
+    EXPECT_TRUE(result.release_json.contains("assets"));
+}
+
+TEST_F(FetchLatestReleaseTest, StripsVPrefix)
+{
+    setup_curl_mock(make_release_json("v3.1.0"));
+
+    auto result = Updater::fetch_latest_release();
+    EXPECT_EQ(result.version, "3.1.0");
+}
+
+TEST_F(FetchLatestReleaseTest, TagWithoutVPrefix)
+{
+    setup_curl_mock(make_release_json("1.5.0"));
+
+    auto result = Updater::fetch_latest_release();
+    EXPECT_EQ(result.version, "1.5.0");
+}
+
+TEST_F(FetchLatestReleaseTest, RateLimitResponse)
+{
+    setup_curl_mock(R"({"message": "API rate limit exceeded for user", "status": "403"})");
+
+    EXPECT_THROW(
+        { auto r = Updater::fetch_latest_release(); },
+        std::runtime_error);
+    try
+    {
+        auto r = Updater::fetch_latest_release();
+    }
+    catch (const std::runtime_error &e)
+    {
+        EXPECT_NE(std::string(e.what()).find("rate limit"), std::string::npos);
+    }
+}
+
+TEST_F(FetchLatestReleaseTest, InvalidJsonResponse)
+{
+    setup_curl_mock("this is not json");
+
+    EXPECT_THROW(
+        { auto r = Updater::fetch_latest_release(); },
+        std::runtime_error);
+    try
+    {
+        auto r = Updater::fetch_latest_release();
+    }
+    catch (const std::runtime_error &e)
+    {
+        EXPECT_NE(std::string(e.what()).find("parse"), std::string::npos);
+    }
+}
+
+TEST_F(FetchLatestReleaseTest, EmptyJsonResponse)
+{
+    setup_curl_mock("");
+
+    EXPECT_THROW(
+        { auto r = Updater::fetch_latest_release(); },
+        std::runtime_error);
+}
+
+TEST_F(FetchLatestReleaseTest, CurlNetworkError)
+{
+    setup_curl_mock_throwing("Connection refused");
+
+    EXPECT_THROW(
+        { auto r = Updater::fetch_latest_release(); },
+        std::runtime_error);
+    try
+    {
+        auto r = Updater::fetch_latest_release();
+    }
+    catch (const std::runtime_error &e)
+    {
+        EXPECT_NE(std::string(e.what()).find("Failed to fetch release info"), std::string::npos);
+    }
+}
+
+TEST_F(FetchLatestReleaseTest, GithubApiErrorMessage)
+{
+    setup_curl_mock(R"({"message": "Not Found", "status": "404"})");
+
+    EXPECT_THROW(
+        { auto r = Updater::fetch_latest_release(); },
+        std::runtime_error);
+    try
+    {
+        auto r = Updater::fetch_latest_release();
+    }
+    catch (const std::runtime_error &e)
+    {
+        EXPECT_NE(std::string(e.what()).find("Not Found"), std::string::npos);
+    }
+}
+
+class ExecuteCurlTest : public MockedUpdaterTest
+{
+};
+
+TEST_F(ExecuteCurlTest, UsesMockWhenSet)
+{
+    Updater::set_curl_executor_for_testing(
+        [](const std::string &url, const std::vector<std::string> &args) -> std::string
+        {
+            return "mocked:" + url;
+        });
+
+    std::string result = Updater::execute_curl("https://example.com");
+    EXPECT_EQ(result, "mocked:https://example.com");
+}
+
+TEST_F(ExecuteCurlTest, MockSeesExtraArgs)
+{
+    Updater::set_curl_executor_for_testing(
+        [](const std::string &url, const std::vector<std::string> &args) -> std::string
+        {
+            return std::to_string(args.size());
+        });
+
+    std::string result = Updater::execute_curl("https://example.com", {"-H", "Accept: json"});
+    EXPECT_EQ(result, "2");
+}
+
+class DownloadAssetTest : public MockedUpdaterTest
+{
+};
+
+TEST_F(DownloadAssetTest, MockDownloaderReturnsTrue)
+{
+    Updater::set_file_downloader_for_testing(
+        [](const std::string &url, const std::string &dest, int64_t size) -> bool
+        {
+            return true;
+        });
+
+    EXPECT_TRUE(Updater::download_asset("https://example.com/file", "/tmp/fake_dest"));
+}
+
+TEST_F(DownloadAssetTest, MockDownloaderReturnsFalse)
+{
+    Updater::set_file_downloader_for_testing(
+        [](const std::string &url, const std::string &dest, int64_t size) -> bool
+        {
+            return false;
+        });
+
+    EXPECT_FALSE(Updater::download_asset("https://example.com/file", "/tmp/fake_dest"));
+}
+
+TEST_F(DownloadAssetTest, MockReceivesExpectedSize)
+{
+    int64_t captured_size = -1;
+    Updater::set_file_downloader_for_testing(
+        [&captured_size](const std::string &url, const std::string &dest, int64_t size) -> bool
+        {
+            captured_size = size;
+            return true;
+        });
+
+    Updater::download_asset("https://example.com/file", "/tmp/fake_dest", 12345);
+    EXPECT_EQ(captured_size, 12345);
+}
+
+TEST_F(DownloadAssetTest, RejectsNonHttpsUrl)
+{
+    EXPECT_FALSE(Updater::download_asset("file:///nonexistent/path/that/does/not/exist", "/tmp/tb_test_dl"));
+}
+
+class GetExePathTest : public MockedUpdaterTest
+{
+};
+
+TEST_F(GetExePathTest, ReturnsNonEmpty)
+{
+    std::string path = Updater::get_exe_path();
+    EXPECT_FALSE(path.empty());
+    EXPECT_TRUE(fs::exists(path)) << "get_exe_path returned non-existent path: " << path;
+}
+
+TEST_F(GetExePathTest, UsesOverride)
+{
+    Updater::set_exe_path_provider_for_testing([]() { return "/custom/path/binary"; });
+    EXPECT_EQ(Updater::get_exe_path(), "/custom/path/binary");
+}
+
+class PerformUpdateTest : public ::testing::Test
+{
+protected:
+    fs::path temp_dir;
+
+    void SetUp() override
+    {
+        temp_dir = fs::temp_directory_path() / "tb_update_test";
+        fs::create_directories(temp_dir);
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(temp_dir);
+    }
+
+    void write_file(const std::string &name, const std::string &content)
+    {
+        std::ofstream(temp_dir / name) << content;
+    }
+
+    std::string read_file(const std::string &name)
+    {
+        std::ifstream f(temp_dir / name);
+        std::string content;
+        std::getline(f, content);
+        return content;
+    }
+};
+
+TEST_F(PerformUpdateTest, SwapsBinariesAndKeepsBackupForRollback)
+{
+    std::string current = (temp_dir / "current_bin").string();
+    std::string newbin = (temp_dir / "new_bin").string();
+
+    write_file("current_bin", "old content");
+    write_file("new_bin", "new content");
+
+    EXPECT_EQ(Updater::perform_update(newbin, current), UpdateResult::Success);
+
+    EXPECT_FALSE(fs::exists(temp_dir / "new_bin"));
+    EXPECT_TRUE(fs::exists(temp_dir / "current_bin.old"));
+    EXPECT_EQ(read_file("current_bin.old"), "old content");
+    EXPECT_EQ(read_file("current_bin"), "new content");
+}
+
+TEST_F(PerformUpdateTest, ReplacesStaleBackupAtStartOfSwap)
+{
+    std::string current = (temp_dir / "current_bin").string();
+    std::string newbin = (temp_dir / "new_bin").string();
+
+    write_file("current_bin", "old");
+    write_file("new_bin", "new");
+    write_file("current_bin.old", "stale backup");
+
+    EXPECT_EQ(Updater::perform_update(newbin, current), UpdateResult::Success);
+
+    EXPECT_TRUE(fs::exists(temp_dir / "current_bin.old"));
+    EXPECT_EQ(read_file("current_bin.old"), "old");
+    EXPECT_EQ(read_file("current_bin"), "new");
+}
+
+TEST_F(PerformUpdateTest, FailsIfNewBinaryMissing)
+{
+    std::string current = (temp_dir / "current_bin").string();
+    std::string newbin = (temp_dir / "nonexistent").string();
+
+    write_file("current_bin", "old");
+
+    EXPECT_THROW(Updater::perform_update(newbin, current), std::runtime_error);
+}
+
+class PerformRollbackTest : public ::testing::Test
+{
+protected:
+    fs::path temp_dir;
+
+    void SetUp() override
+    {
+        temp_dir = fs::temp_directory_path() / "tb_rollback_test";
+        fs::create_directories(temp_dir);
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(temp_dir);
+    }
+
+    void write_file(const std::string &name, const std::string &content)
+    {
+        std::ofstream(temp_dir / name) << content;
+    }
+
+    std::string read_file(const std::string &name)
+    {
+        std::ifstream f(temp_dir / name);
+        std::string content;
+        std::getline(f, content);
+        return content;
+    }
+};
+
+TEST_F(PerformRollbackTest, RestoresOldVersion)
+{
+    std::string current = (temp_dir / "current_bin").string();
+
+    write_file("current_bin", "new version");
+    write_file("current_bin.old", "old version");
+
+    EXPECT_TRUE(Updater::perform_rollback(current));
+    EXPECT_FALSE(fs::exists(temp_dir / "current_bin.old"));
+    EXPECT_EQ(read_file("current_bin"), "old version");
+}
+
+TEST_F(PerformRollbackTest, FailsWithoutOldFile)
+{
+    std::string current = (temp_dir / "current_bin").string();
+    write_file("current_bin", "new version");
+
+    EXPECT_THROW(Updater::perform_rollback(current), std::runtime_error);
+    try
+    {
+        Updater::perform_rollback(current);
+    }
+    catch (const std::runtime_error &e)
+    {
+        EXPECT_NE(std::string(e.what()).find("does not exist"), std::string::npos);
+    }
+}
+
+TEST_F(PerformRollbackTest, FailsWithNonexistentCurrentDir)
+{
+    std::string current = (temp_dir / "no_such_dir" / "bin").string();
+    std::string old_path = current + ".old";
+
+    EXPECT_THROW(Updater::perform_rollback(current), std::runtime_error);
+}
+
+class VerifyChecksumTest : public ::testing::Test
+{
+protected:
+    fs::path temp_dir;
+
+    void SetUp() override
+    {
+        temp_dir = fs::temp_directory_path() / "tb_checksum_test";
+        fs::create_directories(temp_dir);
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(temp_dir);
+    }
+};
+
+TEST_F(VerifyChecksumTest, ReturnsFalseForMissingFile)
+{
+    EXPECT_FALSE(Updater::verify_checksum((temp_dir / "nonexistent").string(), "abc123"));
+}
+
+class VerifyChecksumMatchTest : public ::testing::Test
+{
+protected:
+    fs::path temp_dir;
+
+    void SetUp() override
+    {
+        temp_dir = fs::temp_directory_path() / "tb_checksum_match_test";
+        fs::create_directories(temp_dir);
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(temp_dir);
+    }
+};
+
+TEST_F(VerifyChecksumMatchTest, ReturnsTrueForCorrectHash)
+{
+    std::string filepath = (temp_dir / "test_file").string();
+    {
+        std::ofstream f(filepath);
+        f << "hello world";
+    }
+
+    const std::string expected_hash =
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+
+    EXPECT_TRUE(Updater::verify_checksum(filepath, expected_hash));
+}
+
+TEST_F(VerifyChecksumMatchTest, ReturnsFalseForWrongHash)
+{
+    std::string filepath = (temp_dir / "test_file2").string();
+    {
+        std::ofstream f(filepath);
+        f << "hello world";
+    }
+
+    EXPECT_FALSE(Updater::verify_checksum(filepath, "0000000000000000000000000000000000000000000000000000000000000000"));
+}
+
+TEST_F(VerifyChecksumMatchTest, ReturnsTrueForUpperCaseHash)
+{
+    std::string filepath = (temp_dir / "test_file3").string();
+    {
+        std::ofstream f(filepath);
+        f << "test content";
+    }
+
+    const std::string expected_hash =
+        "6AE8A75555209FD6C44157C0AED8016E763FF435A19CF186F76863140143FF72";
+
+    EXPECT_TRUE(Updater::verify_checksum(filepath, expected_hash));
+}
+
+TEST(BuildScriptLaunchCmdTest, ReturnsEnvVarCommand)
+{
+    EXPECT_EQ(Updater::build_script_launch_cmd(),
+              "cmd /c start \"\" /b \"%TB_LAUNCH_SCRIPT%\"");
+}
+
+class GetAssetSizeTest : public ::testing::Test
+{
+};
+
+TEST_F(GetAssetSizeTest, ReturnsSizeForMatchingUrl)
+{
+    nlohmann::json j = R"({
+        "assets": [
+            {"name": "binary", "browser_download_url": "https://example.com/binary", "size": 12345},
+            {"name": "other", "browser_download_url": "https://example.com/other", "size": 99999}
+        ]
+    })"_json;
+
+    EXPECT_EQ(Updater::get_asset_size(j, "https://example.com/binary"), 12345);
+}
+
+TEST_F(GetAssetSizeTest, ReturnsZeroForUnknownUrl)
+{
+    nlohmann::json j = R"({
+        "assets": [
+            {"name": "binary", "browser_download_url": "https://example.com/binary", "size": 12345}
+        ]
+    })"_json;
+
+    EXPECT_EQ(Updater::get_asset_size(j, "https://example.com/nonexistent"), 0);
+}
+
+TEST_F(GetAssetSizeTest, ReturnsZeroForMissingSizeField)
+{
+    nlohmann::json j = R"({
+        "assets": [
+            {"name": "binary", "browser_download_url": "https://example.com/binary"}
+        ]
+    })"_json;
+
+    EXPECT_EQ(Updater::get_asset_size(j, "https://example.com/binary"), 0);
+}
+
+class IsSafeUrlTest : public ::testing::Test
+{
+};
+
+TEST_F(IsSafeUrlTest, AcceptsValidHttpsUrl)
+{
+    EXPECT_TRUE(Updater::is_safe_url("https://api.github.com/repos/user/repo/releases/latest"));
+    EXPECT_TRUE(Updater::is_safe_url("https://example.com/file?query=1&other=2"));
+    EXPECT_TRUE(Updater::is_safe_url("https://example.com/path%20with%20spaces"));
+    EXPECT_TRUE(Updater::is_safe_url("https://example.com/%2F%2f%41%4a"));
+}
+
+TEST_F(IsSafeUrlTest, RejectsInvalidPercentEncoding)
+{
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/%PATH%"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/%TEMP%file"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/file%"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/%2"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/%GG"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/100%real"));
+}
+
+TEST_F(IsSafeUrlTest, RejectsHttpUrl)
+{
+    EXPECT_FALSE(Updater::is_safe_url("http://example.com/file"));
+}
+
+TEST_F(IsSafeUrlTest, RejectsShellMetacharacters)
+{
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/file\"injection"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/file$(whoami)"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/file`id`"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/file;rm -rf /"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/file|cat"));
+    EXPECT_FALSE(Updater::is_safe_url("https://example.com/file\\n"));
+}
+
+TEST_F(IsSafeUrlTest, RejectsEmptyString)
+{
+    EXPECT_FALSE(Updater::is_safe_url(""));
+}
+
+class FetchChecksumsTest : public MockedUpdaterTest
+{
+};
+
+TEST_F(FetchChecksumsTest, ReturnsChecksumsWhenPresent)
+{
+    std::string release = make_release_json("v1.0.0", "", {
+        {"checksums.txt", "https://example.com/checksums.txt"},
+        {"torrent_builder_1.0.0_linux_amd64", "https://example.com/binary"}
+    });
+    int call_count = 0;
+    Updater::set_curl_executor_for_testing(
+        [&](const std::string &url, const std::vector<std::string> &) -> std::string
+        {
+            call_count++;
+            if (url.find("checksums") != std::string::npos)
+            {
+                return "abc123  torrent_builder_1.0.0_linux_amd64\n";
+            }
+            return release;
+        });
+
+    auto result = Updater::fetch_checksums();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result->find("abc123"), std::string::npos);
+}
+
+TEST_F(FetchChecksumsTest, ReturnsNulloptWhenNoChecksumsAsset)
+{
+    std::string release = make_release_json("v1.0.0", "", {
+        {"torrent_builder_1.0.0_linux_amd64", "https://example.com/binary"}
+    });
+    setup_curl_mock(release);
+
+    auto result = Updater::fetch_checksums();
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FetchChecksumsTest, JsonOverloadAvoidsExtraApiCall)
+{
+    nlohmann::json j = nlohmann::json::parse(make_release_json("v1.0.0", "", {
+        {"checksums.txt", "https://example.com/checksums.txt"},
+        {"torrent_builder_1.0.0_linux_amd64", "https://example.com/binary"}
+    }));
+
+    int call_count = 0;
+    Updater::set_curl_executor_for_testing(
+        [&](const std::string &url, const std::vector<std::string> &) -> std::string
+        {
+            call_count++;
+            return "abc123  torrent_builder_1.0.0_linux_amd64\n";
+        });
+
+    auto result = Updater::fetch_checksums(j);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(call_count, 1);
+}
+
+TEST_F(FetchChecksumsTest, JsonOverloadReturnsNulloptWhenNoChecksumsAsset)
+{
+    nlohmann::json j = nlohmann::json::parse(make_release_json("v1.0.0", "", {
+        {"torrent_builder_1.0.0_linux_amd64", "https://example.com/binary"}
+    }));
+
+    auto result = Updater::fetch_checksums(j);
+    EXPECT_FALSE(result.has_value());
+}
+
+int handle_update_command(const std::vector<std::string> &args);
+
+class HandleUpdateCommandTest : public MockedUpdaterTest
+{
+protected:
+    std::streambuf *old_cout_ = nullptr;
+    std::streambuf *old_cerr_ = nullptr;
+    std::ostringstream captured_out_;
+    std::ostringstream captured_err_;
+
+    void SetUp() override
+    {
+        old_cout_ = std::cout.rdbuf(captured_out_.rdbuf());
+        old_cerr_ = std::cerr.rdbuf(captured_err_.rdbuf());
+    }
+
+    void TearDown() override
+    {
+        std::cout.rdbuf(old_cout_);
+        std::cerr.rdbuf(old_cerr_);
+        Updater::reset_test_overrides();
+    }
+
+    static std::string release_with_version(const std::string &version)
+    {
+        auto platform = Updater::get_platform_info();
+        std::string ext;
+        if (platform.os == "windows")
+            ext = ".exe";
+        else if (platform.os == "macos")
+            ext = ".zip";
+
+        nlohmann::json j;
+        j["tag_name"] = version;
+        j["body"] = "Test release";
+        j["assets"] = nlohmann::json::array();
+        j["assets"].push_back({{"name", "torrent_builder_" + version + "_" + platform.os + "_" + platform.arch + ext},
+                               {"browser_download_url", "https://example.com/binary"}});
+        j["assets"].push_back({{"name", "checksums.txt"},
+                               {"browser_download_url", "https://example.com/checksums.txt"}});
+        return j.dump();
+    }
+
+    static std::string asset_name_for_version(const std::string &version)
+    {
+        auto platform = Updater::get_platform_info();
+        std::string ext;
+        if (platform.os == "windows")
+            ext = ".exe";
+        else if (platform.os == "macos")
+            ext = ".zip";
+        return "torrent_builder_" + version + "_" + platform.os + "_" + platform.arch + ext;
+    }
+};
+
+TEST_F(HandleUpdateCommandTest, HelpReturnsZero)
+{
+    EXPECT_EQ(handle_update_command({"--help"}), 0);
+    EXPECT_NE(captured_out_.str().find("update"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, CheckShowsUpdateAvailable)
+{
+    Updater::set_current_version_for_testing("0.5.0");
+    setup_curl_mock(release_with_version("2.0.0"));
+
+    EXPECT_EQ(handle_update_command({"--check"}), 0);
+    EXPECT_NE(captured_out_.str().find("2.0.0"), std::string::npos);
+    EXPECT_NE(captured_out_.str().find("Update available"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, CheckShowsAlreadyUpToDate)
+{
+    Updater::set_current_version_for_testing("2.0.0");
+    setup_curl_mock(release_with_version("2.0.0"));
+
+    EXPECT_EQ(handle_update_command({"--check"}), 0);
+    EXPECT_NE(captured_out_.str().find("Already up to date"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, DevVersionAlwaysShowsUpdate)
+{
+    Updater::set_current_version_for_testing("dev");
+    setup_curl_mock(release_with_version("0.0.0"));
+
+    EXPECT_EQ(handle_update_command({"--check"}), 0);
+    std::string output = captured_out_.str();
+    EXPECT_TRUE(output.find("Update available") != std::string::npos ||
+                output.find("Latest") != std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, FetchFailureReturnsOne)
+{
+    setup_curl_mock_throwing("Network error");
+
+    EXPECT_EQ(handle_update_command({"--check"}), 1);
+}
+
+TEST_F(HandleUpdateCommandTest, YesFlagSkipsPrompt)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+    setup_curl_mock(release_with_version("2.0.0"));
+
+    fs::path temp = fs::temp_directory_path() / "tb_handle_update_test";
+    fs::create_directories(temp);
+    std::string fake_bin = (temp / "current").string();
+    std::string old_bin = fake_bin + ".old";
+    {
+        std::ofstream(fake_bin) << "old binary";
+    }
+    fs::permissions(fake_bin, fs::perms::owner_all);
+
+    Updater::set_exe_path_provider_for_testing([fake_bin]() { return fake_bin; });
+
+    Updater::set_binary_validator_for_testing([](const std::string &) { return true; });
+
+    Updater::set_file_downloader_for_testing(
+        [temp](const std::string &, const std::string &dest_path, int64_t) -> bool
+        {
+#ifdef __APPLE__
+            return create_mock_zip(dest_path, "new binary content for update");
+#else
+            std::ofstream(dest_path) << "new binary content for update";
+            return true;
+#endif
+        });
+
+    int rc = handle_update_command({"--yes"});
+
+    Updater::reset_test_overrides();
+    fs::remove_all(temp);
+
+    EXPECT_EQ(rc, 0);
+}
+
+TEST_F(HandleUpdateCommandTest, DownloadFailureReturnsOne)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+    setup_curl_mock(release_with_version("2.0.0"));
+
+    Updater::set_file_downloader_for_testing(
+        [](const std::string &, const std::string &, int64_t) -> bool
+        {
+            return false;
+        });
+
+    Updater::set_exe_path_provider_for_testing([]() { return "/tmp/fake_binary"; });
+
+    EXPECT_EQ(handle_update_command({"--yes"}), 1);
+}
+
+TEST_F(HandleUpdateCommandTest, RollbackSuccess)
+{
+    fs::path temp = fs::temp_directory_path() / "tb_rollback_cmd_test";
+    fs::create_directories(temp);
+    std::string fake_bin = (temp / "current").string();
+    std::string old_bin = fake_bin + ".old";
+
+    {
+        std::ofstream(fake_bin) << "new binary";
+        std::ofstream(old_bin) << "old binary";
+    }
+    fs::permissions(fake_bin, fs::perms::owner_all);
+    fs::permissions(old_bin, fs::perms::owner_all);
+
+    Updater::set_exe_path_provider_for_testing([fake_bin]() { return fake_bin; });
+
+    std::istringstream input("y\n");
+    auto *old_cin = std::cin.rdbuf(input.rdbuf());
+
+    int rc = handle_update_command({"--rollback"});
+
+    std::cin.rdbuf(old_cin);
+
+    fs::remove_all(temp);
+
+    EXPECT_EQ(rc, 0);
+}
+
+TEST_F(HandleUpdateCommandTest, RollbackCancelled)
+{
+    fs::path temp = fs::temp_directory_path() / "tb_rollback_cancel_test";
+    fs::create_directories(temp);
+    std::string fake_bin = (temp / "current").string();
+    std::string old_bin = fake_bin + ".old";
+
+    {
+        std::ofstream(fake_bin) << "new";
+        std::ofstream(old_bin) << "old";
+    }
+
+    Updater::set_exe_path_provider_for_testing([fake_bin]() { return fake_bin; });
+
+    std::istringstream input("n\n");
+    auto *old_cin = std::cin.rdbuf(input.rdbuf());
+
+    int rc = handle_update_command({"--rollback"});
+
+    std::cin.rdbuf(old_cin);
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_NE(captured_out_.str().find("cancelled"), std::string::npos);
+
+    fs::remove_all(temp);
+}
+
+TEST_F(HandleUpdateCommandTest, RollbackNoOldFileReturnsOne)
+{
+    Updater::set_exe_path_provider_for_testing([]() { return "/tmp/nonexistent_binary_tb_test"; });
+
+    std::istringstream input("y\n");
+    auto *old_cin = std::cin.rdbuf(input.rdbuf());
+
+    int rc = handle_update_command({"--rollback"});
+
+    std::cin.rdbuf(old_cin);
+
+    EXPECT_EQ(rc, 1);
+}
+
+TEST_F(HandleUpdateCommandTest, NoMatchingPlatformReturnsOne)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+
+    nlohmann::json j;
+    j["tag_name"] = "v99.0.0";
+    j["body"] = "";
+    j["assets"] = nlohmann::json::array();
+    j["assets"].push_back({{"name", "torrent_builder_99.0.0_windows_amd64.exe"},
+                           {"browser_download_url", "https://example.com/win_only"}});
+    setup_curl_mock(j.dump());
+
+    EXPECT_EQ(handle_update_command({"--yes"}), 1);
+}
+
+TEST_F(HandleUpdateCommandTest, ChecksumVerificationSuccess)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+
+    std::string asset_name = asset_name_for_version("2.0.0");
+
+    std::string test_content = "new binary content for checksum test";
+    std::string actual_hash =
+        "6356eb22316bf8a23ea42ef2d7ede5ea829140b4dae064b01b96f9e9c9b5a1fa";
+
+    nlohmann::json j;
+    j["tag_name"] = "v2.0.0";
+    j["body"] = "Test release";
+    j["assets"] = nlohmann::json::array();
+    j["assets"].push_back({{"name", asset_name},
+                           {"browser_download_url", "https://github.com/user/repo/releases/download/v2.0.0/" + asset_name}});
+    j["assets"].push_back({{"name", "checksums.txt"},
+                           {"browser_download_url", "https://github.com/user/repo/releases/download/v2.0.0/checksums.txt"}});
+
+    std::string captured_hash;
+
+    Updater::set_curl_executor_for_testing(
+        [j, actual_hash, asset_name, &captured_hash](const std::string &url, const std::vector<std::string> &) -> std::string
+        {
+            if (url.find("checksums") != std::string::npos)
+            {
+                std::string hash = captured_hash.empty() ? actual_hash : captured_hash;
+                return hash + "  " + asset_name + "\n";
+            }
+            return j.dump();
+        });
+
+    fs::path temp = fs::temp_directory_path() / "tb_checksum_verify_test";
+    fs::create_directories(temp);
+    std::string fake_bin = (temp / "current").string();
+    {
+        std::ofstream(fake_bin) << "old binary";
+    }
+    fs::permissions(fake_bin, fs::perms::owner_all);
+
+    Updater::set_exe_path_provider_for_testing([fake_bin]() { return fake_bin; });
+
+    Updater::set_file_downloader_for_testing(
+        [&captured_hash, test_content](const std::string &, const std::string &dest_path, int64_t) -> bool
+        {
+#ifdef __APPLE__
+            bool ok = create_mock_zip(dest_path, test_content);
+            if (ok)
+                captured_hash = sha256_file(dest_path);
+            return ok;
+#else
+            std::ofstream(dest_path) << test_content;
+            return true;
+#endif
+        });
+
+    int rc = handle_update_command({"--yes"});
+
+    Updater::reset_test_overrides();
+    fs::remove_all(temp);
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_NE(captured_out_.str().find("Checksum verified"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, ChecksumMismatchReturnsOne)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+
+    std::string asset_name = asset_name_for_version("2.0.0");
+
+    nlohmann::json j;
+    j["tag_name"] = "v2.0.0";
+    j["body"] = "Test release";
+    j["assets"] = nlohmann::json::array();
+    j["assets"].push_back({{"name", asset_name},
+                           {"browser_download_url", "https://github.com/user/repo/releases/download/v2.0.0/" + asset_name}});
+    j["assets"].push_back({{"name", "checksums.txt"},
+                           {"browser_download_url", "https://github.com/user/repo/releases/download/v2.0.0/checksums.txt"}});
+
+    Updater::set_curl_executor_for_testing(
+        [j, asset_name](const std::string &url, const std::vector<std::string> &) -> std::string
+        {
+            if (url.find("checksums") != std::string::npos)
+            {
+                return "0000000000000000000000000000000000000000000000000000000000000000  " + asset_name + "\n";
+            }
+            return j.dump();
+        });
+
+    fs::path temp = fs::temp_directory_path() / "tb_checksum_mismatch_test";
+    fs::create_directories(temp);
+    std::string fake_bin = (temp / "current").string();
+    {
+        std::ofstream(fake_bin) << "old binary";
+    }
+    fs::permissions(fake_bin, fs::perms::owner_all);
+
+    Updater::set_exe_path_provider_for_testing([fake_bin]() { return fake_bin; });
+
+    Updater::set_file_downloader_for_testing(
+        [](const std::string &, const std::string &dest_path, int64_t) -> bool
+        {
+            std::ofstream(dest_path) << "downloaded binary content";
+            return true;
+        });
+
+    int rc = handle_update_command({"--yes"});
+
+    Updater::reset_test_overrides();
+    fs::remove_all(temp);
+
+    EXPECT_EQ(rc, 1);
+    EXPECT_NE(captured_err_.str().find("Checksum verification failed"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, DevVersionBypassWhenNewer)
+{
+    Updater::set_current_version_for_testing("dev");
+    setup_curl_mock(release_with_version("0.0.1"));
+
+    EXPECT_EQ(handle_update_command({"--check"}), 0);
+    std::string output = captured_out_.str();
+    EXPECT_TRUE(output.find("Update available") != std::string::npos ||
+                output.find("Latest") != std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, DevVersionAheadOfReleaseDeclinesUpdate)
+{
+    Updater::set_current_version_for_testing("2.0.0-dev");
+    setup_curl_mock(release_with_version("1.0.0"));
+
+    EXPECT_EQ(handle_update_command({"--check"}), 0);
+    EXPECT_NE(captured_out_.str().find("newer than latest release"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, UserDeclinesUpdate)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+    setup_curl_mock(release_with_version("2.0.0"));
+
+    Updater::set_exe_path_provider_for_testing([]() { return "/tmp/fake_binary"; });
+
+    std::istringstream input("n\n");
+    auto *old_cin = std::cin.rdbuf(input.rdbuf());
+
+    int rc = handle_update_command({});
+
+    std::cin.rdbuf(old_cin);
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_NE(captured_out_.str().find("cancelled"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, ProceedsWithoutChecksumsWhenAbsentFromRelease)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+
+    std::string asset_name = asset_name_for_version("2.0.0");
+
+    nlohmann::json j;
+    j["tag_name"] = "v2.0.0";
+    j["body"] = "Test release";
+    j["assets"] = nlohmann::json::array();
+    j["assets"].push_back({{"name", asset_name},
+                           {"browser_download_url", "https://github.com/user/repo/releases/download/v2.0.0/" + asset_name}});
+
+    setup_curl_mock(j.dump());
+
+    fs::path temp = fs::temp_directory_path() / "tb_no_checksums_test";
+    fs::create_directories(temp);
+    std::string fake_bin = (temp / "current").string();
+    {
+        std::ofstream(fake_bin) << "old binary";
+    }
+    fs::permissions(fake_bin, fs::perms::owner_all);
+
+    Updater::set_exe_path_provider_for_testing([fake_bin]() { return fake_bin; });
+
+    Updater::set_binary_validator_for_testing([](const std::string &) { return true; });
+
+    Updater::set_file_downloader_for_testing(
+        [](const std::string &, const std::string &dest_path, int64_t) -> bool
+        {
+#ifdef __APPLE__
+            return create_mock_zip(dest_path, "new binary without checksums");
+#else
+            std::ofstream(dest_path) << "new binary without checksums";
+            return true;
+#endif
+        });
+
+    int rc = handle_update_command({"--yes"});
+
+    Updater::reset_test_overrides();
+    fs::remove_all(temp);
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_NE(captured_out_.str().find("Successfully updated"), std::string::npos);
+}
+
+TEST_F(HandleUpdateCommandTest, ProceedsWithoutChecksumWhenAssetNotListed)
+{
+    Updater::set_current_version_for_testing("0.1.0");
+
+    std::string asset_name = asset_name_for_version("2.0.0");
+
+    nlohmann::json j;
+    j["tag_name"] = "v2.0.0";
+    j["body"] = "Test release";
+    j["assets"] = nlohmann::json::array();
+    j["assets"].push_back({{"name", asset_name},
+                           {"browser_download_url", "https://github.com/user/repo/releases/download/v2.0.0/" + asset_name}});
+    j["assets"].push_back({{"name", "checksums.txt"},
+                           {"browser_download_url", "https://github.com/user/repo/releases/download/v2.0.0/checksums.txt"}});
+
+    Updater::set_curl_executor_for_testing(
+        [j](const std::string &url, const std::vector<std::string> &) -> std::string
+        {
+            if (url.find("checksums") != std::string::npos)
+            {
+                return "abcdef1234567890  other_platform_binary\n";
+            }
+            return j.dump();
+        });
+
+    fs::path temp = fs::temp_directory_path() / "tb_no_asset_checksum_test";
+    fs::create_directories(temp);
+    std::string fake_bin = (temp / "current").string();
+    {
+        std::ofstream(fake_bin) << "old binary";
+    }
+    fs::permissions(fake_bin, fs::perms::owner_all);
+
+    Updater::set_exe_path_provider_for_testing([fake_bin]() { return fake_bin; });
+
+    Updater::set_binary_validator_for_testing([](const std::string &) { return true; });
+
+    Updater::set_file_downloader_for_testing(
+        [](const std::string &, const std::string &dest_path, int64_t) -> bool
+        {
+#ifdef __APPLE__
+            return create_mock_zip(dest_path, "new binary asset not in checksums");
+#else
+            std::ofstream(dest_path) << "new binary asset not in checksums";
+            return true;
+#endif
+        });
+
+    int rc = handle_update_command({"--yes"});
+
+    Updater::reset_test_overrides();
+    fs::remove_all(temp);
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_NE(captured_out_.str().find("Successfully updated"), std::string::npos);
+}
+
+class IsValidBinaryTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { Updater::reset_test_overrides(); }
+    void TearDown() override { Updater::reset_test_overrides(); }
+};
+
+TEST_F(IsValidBinaryTest, RecognizesElfMagic)
+{
+    auto path = fs::temp_directory_path() / "test_elf_binary";
+    {
+        std::ofstream f(path, std::ios::binary);
+        unsigned char elf[] = {0x7f, 'E', 'L', 'F', 0x02, 0x01, 0x01, 0x00};
+        f.write(reinterpret_cast<char *>(elf), sizeof(elf));
+    }
+    EXPECT_TRUE(Updater::is_valid_binary(path.string()));
+    fs::remove(path);
+}
+
+TEST_F(IsValidBinaryTest, RecognizesPeMagic)
+{
+    auto path = fs::temp_directory_path() / "test_pe_binary";
+    {
+        std::ofstream f(path, std::ios::binary);
+        unsigned char pe[] = {'M', 'Z', 0x90, 0x00};
+        f.write(reinterpret_cast<char *>(pe), sizeof(pe));
+    }
+    EXPECT_TRUE(Updater::is_valid_binary(path.string()));
+    fs::remove(path);
+}
+
+TEST_F(IsValidBinaryTest, RecognizesMachO64Magic)
+{
+    auto path = fs::temp_directory_path() / "test_macho_binary";
+    {
+        std::ofstream f(path, std::ios::binary);
+        unsigned char macho[] = {0xfe, 0xed, 0xfa, 0xcf, 0x00, 0x00, 0x00, 0x01};
+        f.write(reinterpret_cast<char *>(macho), sizeof(macho));
+    }
+    EXPECT_TRUE(Updater::is_valid_binary(path.string()));
+    fs::remove(path);
+}
+
+TEST_F(IsValidBinaryTest, RecognizesMachO32Magic)
+{
+    auto path = fs::temp_directory_path() / "test_macho32_binary";
+    {
+        std::ofstream f(path, std::ios::binary);
+        unsigned char macho[] = {0xfe, 0xed, 0xfa, 0xce, 0x00, 0x00, 0x00, 0x01};
+        f.write(reinterpret_cast<char *>(macho), sizeof(macho));
+    }
+    EXPECT_TRUE(Updater::is_valid_binary(path.string()));
+    fs::remove(path);
+}
+
+TEST_F(IsValidBinaryTest, RejectsNonBinary)
+{
+    auto path = fs::temp_directory_path() / "test_text_file";
+    {
+        std::ofstream f(path);
+        f << "Hello, this is a text file";
+    }
+    EXPECT_FALSE(Updater::is_valid_binary(path.string()));
+    fs::remove(path);
+}
+
+TEST_F(IsValidBinaryTest, RejectsMissingFile)
+{
+    EXPECT_FALSE(Updater::is_valid_binary("/nonexistent/path/binary"));
+}
+
+TEST_F(IsValidBinaryTest, RejectsEmptyFile)
+{
+    auto path = fs::temp_directory_path() / "test_empty_file";
+    {
+        std::ofstream f(path);
+    }
+    EXPECT_FALSE(Updater::is_valid_binary(path.string()));
+    fs::remove(path);
+}
+
+class PerformUpdateFailureTest : public ::testing::Test
+{
+protected:
+    fs::path temp_dir;
+
+    void SetUp() override
+    {
+        temp_dir = fs::temp_directory_path() / "tb_update_fail_test";
+        fs::create_directories(temp_dir);
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(temp_dir);
+    }
+
+    void write_file(const std::string &name, const std::string &content)
+    {
+        std::ofstream(temp_dir / name) << content;
+    }
+
+    std::string read_file(const std::string &name)
+    {
+        std::ifstream f(temp_dir / name);
+        std::string content;
+        std::getline(f, content);
+        return content;
+    }
+};
+
+TEST_F(PerformUpdateFailureTest, SwapsWhenExtraDirExists)
+{
+    std::string current = (temp_dir / "current_bin").string();
+    std::string newbin = (temp_dir / "new_bin").string();
+
+    write_file("current_bin", "old content");
+    write_file("new_bin", "new content");
+
+    fs::path extra_dir = temp_dir / "extra";
+    fs::create_directories(extra_dir);
+
+    EXPECT_EQ(Updater::perform_update(newbin, current), UpdateResult::Success);
+
+    EXPECT_FALSE(fs::exists(temp_dir / "new_bin"));
+    EXPECT_TRUE(fs::exists(temp_dir / "current_bin.old"));
+    EXPECT_EQ(read_file("current_bin.old"), "old content");
+    EXPECT_EQ(read_file("current_bin"), "new content");
+}
+
+TEST_F(PerformUpdateFailureTest, FailsWhenCurrentBinaryNotWritable)
+{
+#ifdef _WIN32
+    GTEST_SKIP() << "POSIX-only: fs::perms::none does not prevent writes on Windows";
+#else
+    std::string current = (temp_dir / "readonly_dir" / "current_bin").string();
+    std::string newbin = (temp_dir / "new_bin").string();
+
+    fs::create_directories(temp_dir / "readonly_dir");
+    write_file("readonly_dir/current_bin", "old");
+    write_file("new_bin", "new");
+
+    fs::permissions(temp_dir / "readonly_dir", fs::perms::none);
+
+    EXPECT_THROW(Updater::perform_update(newbin, current), std::runtime_error);
+
+    fs::permissions(temp_dir / "readonly_dir", fs::perms::owner_all);
+#endif
+}
+
+TEST_F(PerformUpdateFailureTest, RollbackRestoresOriginalOnSecondRenameFailure)
+{
+#ifdef _WIN32
+    GTEST_SKIP() << "POSIX-only: relies on directory permission to trigger rename failure";
+#else
+    fs::path src_dir = temp_dir / "srcdir";
+    fs::path tgt_dir = temp_dir / "tgtdir";
+    fs::create_directories(src_dir);
+    fs::create_directories(tgt_dir);
+
+    std::string current = (tgt_dir / "current_bin").string();
+    std::string newbin = (src_dir / "new_bin").string();
+
+    {
+        std::ofstream(current) << "original content";
+        std::ofstream(newbin) << "new content";
+    }
+
+    fs::permissions(src_dir, fs::perms::owner_read | fs::perms::owner_exec);
+
+    try
+    {
+        Updater::perform_update(newbin, current);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error &e)
+    {
+        EXPECT_NE(std::string(e.what()).find("rolled back"), std::string::npos);
+    }
+
+    fs::permissions(src_dir, fs::perms::owner_all);
+
+    EXPECT_TRUE(fs::exists(tgt_dir / "current_bin"));
+    EXPECT_FALSE(fs::exists(tgt_dir / "current_bin.old"));
+
+    std::ifstream f(current);
+    std::string content;
+    std::getline(f, content);
+    EXPECT_EQ(content, "original content");
+#endif
+}


### PR DESCRIPTION
## Summary
Adds a built-in `update` command that lets users check for and install newer versions of torrent-builder directly from GitHub Releases. The implementation includes a new `Updater` class that detects the current platform, queries the GitHub API for the latest release, downloads the matching binary asset, verifies its SHA-256 checksum against a release-attached `checksums.txt`, and atomically replaces the running executable. A `--rollback` flag is included to restore the previous version if needed.

## Motivation
Previously, staying up-to-date required manually downloading releases, verifying them, and replacing the binary. This process is error-prone and inconvenient, especially for users who want to run the latest features or security fixes. By integrating self-update functionality directly into the CLI, torrent-builder can now offer a seamless, safe, and auditable update path with checksum verification and automatic rollback support.

## Changes Made
- Added `Version` struct plus semver parsing and comparison utilities (`include/utils.hpp`, `src/utils.cpp`)
- Added `Updater` class (`include/updater.hpp`, `src/updater.cpp`) covering GitHub release fetching, platform-aware asset matching, curl-based download, SHA-256 checksum verification, atomic binary swap, and rollback
- Integrated `handle_update_command` and update dispatch into `src/torrent_builder.cpp`
- Added a comprehensive test suite (`tests/test_updater.cpp`) with 56 tests covering version parsing, API interaction, download logic, checksum verification, binary replacement, rollback, URL safety, and platform detection
- Updated `CMakeLists.txt` to add `nlohmann/json` via FetchContent, include `src/updater.cpp` in the build, and add the `test_updater` target
- Updated `.github/workflows/release.yml` to generate and attach `checksums.txt` with SHA-256 hashes
- Updated `README.md` with a new Update section documenting flags, prerequisites, and usage examples

## Testing
- [x] Tested locally
- [x] Unit tests added
- [x] Documentation updated

## Breaking Changes
None.

Closes #35

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR adds a `torrent-builder update` command that fetches the latest release from GitHub, verifies its SHA-256 checksum, and atomically replaces the running binary — with a `--rollback` flag to restore the previous version. A new `Version` struct provides semver parsing and comparison, while build, CI, and documentation changes wire everything together. The result is a seamless, auditable self-update path that eliminates manual download-and-replace workflows.

---
<sup>Written for commit 21c61316d889e8aabb7e31be00e31d75d7c02e65. Summary will update on new commits.</sup>
<!-- end-auto-generated -->